### PR TITLE
Use mosdepth d4tools to facilitate coverage calcs

### DIFF
--- a/.test/ecoli/config/config.yaml
+++ b/.test/ecoli/config/config.yaml
@@ -42,18 +42,12 @@ het_prior: 0.005    #prior probabilty of heterozygous site; changes likelihood o
 ########################################
 
 mappability_min: 1    #regions of the genome with mappability less than this will be removed from callable sites bed file
-low_cov_thresh: 0.5   #regions of the genome with coverage below low_cov_thresh * mean coverage will be filtered
-high_cov_thresh: 2    #regions of the genome with coverage above low_cov_thresh * mean coverage will be filtered
-
-#select one of the following, comment the other
-cov_type: "mean_summed_cov"   #use the total coverage to filter
-#cov_type: "mean_ind_cov"     #use the mean individual coverage to filter
+cov_threshold: 2      #regions of the genome with coverage above/below cov_thresh standard deviations will be filtered
 
 #this ignores small regions of abberatant coverage/mappability as often these are just below the threshold
 #to do strict filtering, set to 0
 
 callable_merge: 100   #merge callable regions separated by this or fewer bp into a single region
-
 
 ## QC options ##
 nClusters: 3

--- a/.test/ecoli/config/config.yaml
+++ b/.test/ecoli/config/config.yaml
@@ -21,6 +21,7 @@ minNmer: 500                # the minimum Nmer used to split up the genome; e.g.
 maxIntervalLen: 30000000    # the desired maximum size of an interval for calling variants; more than 2Mb is a good starting point
 maxBpPerList: 30000000      # the desired maximum number of bp per list file for GATK4; list files potentially contain many small intervals, and we cap the fraction of the genome contained in each list file here
 maxIntervalsPerList: 200    # the desired maximum number of intervals per list file for GATK4; this prevents list files from containing thousands of small intervals, which can slow parts of GATK4. Default is good.
+missingBpTolerance: 0       # the number of bp allowed to be missing from the interval list; increase if needed to solve issues with interval creation
 
 ## Coverage options ##
 ## default pipeline is optimized for low coverage data

--- a/.test/ecoli/config/resources.yaml
+++ b/.test/ecoli/config/resources.yaml
@@ -53,6 +53,7 @@ process_ref:
 create_intervals:
     mem: 5000
 
+
 ## Callable sites workflow
 
 # genmap map
@@ -61,8 +62,13 @@ genmap:
     mem: 10000
 genmap_sort:
     mem: 4000
-bedtools:
+compute_d4:
     mem: 4000
+    threads: 4
+merge_d4:
+    mem: 10000
+callable_bed:
+    mem: 10000
 
 ###
 # bam2vcf workflows

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -42,12 +42,7 @@ het_prior: 0.005    #prior probabilty of heterozygous site; changes likelihood o
 ########################################
 
 mappability_min: 1    #regions of the genome with mappability less than this will be removed from callable sites bed file
-low_cov_thresh: 0.5   #regions of the genome with coverage below low_cov_thresh * mean coverage will be filtered
-high_cov_thresh: 2    #regions of the genome with coverage above low_cov_thresh * mean coverage will be filtered
-
-#select one of the following, comment the other
-cov_type: "mean_summed_cov"   #use the total coverage to filter
-#cov_type: "mean_ind_cov"     #use the mean individual coverage to filter
+cov_threshold: 2      #regions of the genome with coverage above/below cov_thresh standard deviations will be filtered
 
 #this ignores small regions of abberatant coverage/mappability as often these are just below the threshold
 #to do strict filtering, set to 0

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -21,6 +21,7 @@ minNmer: 500                # the minimum Nmer used to split up the genome; e.g.
 maxIntervalLen: 20000000    # the desired maximum size of an interval for calling variants; more than 2Mb is a good starting point
 maxBpPerList: 20000000      # the desired maximum number of bp per list file for GATK4; list files potentially contain many small intervals, and we cap the fraction of the genome contained in each list file here
 maxIntervalsPerList: 200    # the desired maximum number of intervals per list file for GATK4; this prevents list files from containing thousands of small intervals, which can slow parts of GATK4. Default is good.
+missingBpTolerance: 0       # the number of bp allowed to be missing from the interval list; increase if needed to solve issues with interval creation
 
 ## Coverage options ##
 ## default pipeline is optimized for low coverage data

--- a/config/resources.yaml
+++ b/config/resources.yaml
@@ -61,8 +61,13 @@ genmap:
     mem: 20000
 genmap_sort:
     mem: 4000
-bedtools:
+compute_d4:
     mem: 4000
+    threads: 4
+merge_d4:
+    mem: 10000
+callable_bed:
+    mem: 10000
 
 ###
 # bam2vcf workflows

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -27,7 +27,7 @@ rule all:
         get_output(REFGENOME,ORGANISM),
         expand(config['output'] + "{Organism}/{refGenome}/" + "bam_sumstats.tsv", zip, Organism=ORGANISM, refGenome=REFGENOME),
         expand(config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}.callable_sites.bed", zip, Organism=ORGANISM, refGenome=REFGENOME)
-
+        
 include: "rules/common.smk"
 include: "rules/fastq2bam.smk"
 include: "rules/intervals.smk"

--- a/workflow/envs/callable.yml
+++ b/workflow/envs/callable.yml
@@ -15,5 +15,6 @@ dependencies:
   - rust
   - gcc
   - binutils
+  - make
   - pip:
       - pyd4

--- a/workflow/envs/callable.yml
+++ b/workflow/envs/callable.yml
@@ -11,5 +11,7 @@ dependencies:
   - genmap>=1.3.0
   - mosdepth>=0.3.3
   - d4tools>=0.3.4
+  - pip
+  - rust
   - pip:
       - pyd4

--- a/workflow/envs/callable.yml
+++ b/workflow/envs/callable.yml
@@ -13,5 +13,6 @@ dependencies:
   - d4tools>=0.3.4
   - pip
   - rust
+  - gcc
   - pip:
       - pyd4

--- a/workflow/envs/callable.yml
+++ b/workflow/envs/callable.yml
@@ -14,5 +14,6 @@ dependencies:
   - pip
   - rust
   - gcc
+  - binutils
   - pip:
       - pyd4

--- a/workflow/envs/callable.yml
+++ b/workflow/envs/callable.yml
@@ -9,3 +9,5 @@ dependencies:
   - ucsc-twobitinfo==377
   - ucsc-bedtobigbed==377
   - genmap>=1.3.0
+  - mosdepth>=0.3.3
+  - d4tools>=0.3.4

--- a/workflow/envs/callable.yml
+++ b/workflow/envs/callable.yml
@@ -11,3 +11,5 @@ dependencies:
   - genmap>=1.3.0
   - mosdepth>=0.3.3
   - d4tools>=0.3.4
+  - pip:
+      - pyd4

--- a/workflow/helperFun.py
+++ b/workflow/helperFun.py
@@ -49,7 +49,7 @@ def collectAlnSumMets(alnSumMetsFiles):
             aln_metrics[sample]["Percent Mapped"] = percent_mapped
             aln_metrics[sample]["Percent Duplicates"] = percent_dups
             aln_metrics[sample]["Percent Properly Paired"] = percent_proper_paired
-    
+
     return(aln_metrics)
 
 def collectCoverageMetrics(coverageFiles):
@@ -126,7 +126,7 @@ def createSeqDictGetScaffOrder(dict_file):
             seqDictScaffs.append(scaff)
     return(seqDictScaffs)
 
-def createListsGetIndices(maxIntervalLen, maxBpPerList, maxIntervalsPerList, minNmer, outputDir, intDir, wildcards, dict_file, intervals_file):
+def createListsGetIndices(missingBpTolerance, maxIntervalLen, maxBpPerList, maxIntervalsPerList, minNmer, outputDir, intDir, wildcards, dict_file, intervals_file):
 
     # Get the order in which scaffolds are listed in genome .dict file,  need to correspond to order in list files! So use .dict order for printing interval files
     seqDictScaffs = createSeqDictGetScaffOrder(dict_file)
@@ -236,7 +236,7 @@ def createListsGetIndices(maxIntervalLen, maxBpPerList, maxIntervalsPerList, min
                         totalACGTmerLength_overlaps += o+1 # add 1 to compare to lengths taken above
 
         maxIntervalLenByNmer[Nmer] = Nmer_maxIntervalLen
-        if totalACGTmerLength_overlaps < totalACGTmerLength:
+        if abs(totalACGTmerLength_overlaps - totalACGTmerLength) > missingBpTolerance:
             print(Nmer, totalACGTmerLength, totalACGTmerLength_overlaps)
             print("Error in interval creation: not all ACGTmers were accounted for")
             sys.exit(1)

--- a/workflow/rules/bam2vcf.smk
+++ b/workflow/rules/bam2vcf.smk
@@ -166,13 +166,15 @@ rule sort_gatherVcfs:
         gather_vcfs_CLI
     conda:
         "../envs/bam2vcf.yml"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * res_config['gatherVcfs']['mem']
     log:
         "logs/{Organism}/sortVcf/{refGenome}.txt"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * res_config['gatherVcfs']['mem'],   # this is the overall memory requested
+        reduced = lambda wildcards, attempt: attempt * (res_config['gatherVcfs']['mem'] - 2000)  # this is the maximum amount given to java
     benchmark:
         "benchmarks/{Organism}/sortVcf/{refGenome}.txt"
     shell:
         "gatk SortVcf "
+        "--java-options \"-Xmx{resources.reduced}m -Xms{resources.reduced}m\" "
         "{params} "
         "-O {output.vcfFinal} &> {log}"

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -173,4 +173,4 @@ rule callable_bed:
     params:
         merge = config['callable_merge']
     shell:
-        "bedtools intersect -a {input.callable_cov} -b {input.callable_map} | bedtools merge -d {params.merge} -i - > {output.callable_sites}"
+        "bedtools intersect -a {input.callable_cov} -b {input.callable_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites}"

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -110,8 +110,8 @@ rule create_cov_bed:
         cov_threshold = config['cov_threshold']
     conda:
         "../envs/callable.yml"
-    shell:
-        "python scripts/create_coverage_bed.py"
+    script:
+        "scripts/create_coverage_bed.py"
 
 rule callable_bed:
     input:

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -98,7 +98,7 @@ rule compute_covstats:
     conda:
         "../envs/callable.yml"
     shell:
-        "d4tools stat {input.d4} | awk '{ for(i=4; i<=NF;i++) j+=$i; print $1,$3,j; j=0 }' > {output}"
+        "d4tools stat {input.d4} | awk '{{ for(i=4; i<=NF;i++) j+=$i; print $1,$3,j; j=0 }}' > {output}"
 
 rule create_cov_bed:
     input:

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -130,8 +130,10 @@ rule callable_bed:
         TEMP_cov = config['tmp_dir'] + "{Organism}_{refGenome}_TEMP.cov.bed",
         TEMP_map = config['tmp_dir'] + "{Organism}_{refGenome}_TEMP.map.bed"
     shell:
-        "bedtools merge {input.cov} > {params.TEMP_cov} "
-        """awk 'BEGIN{{OFS="\\t";FS="\\t"}} {{ if($4>={params.mappability}) print $1,$2,$3 }}' {input.map} > {params.TEMP_map} """
-        "bedtools intersect -a {params.TEMP_cov} -b {params.TEMP_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites} "
-        "rm {params.TEMP_cov} "
-        "rm {params.TEMP_map} "
+        """
+        bedtools merge {input.cov} > {params.TEMP_cov}
+        awk 'BEGIN{{OFS="\\t";FS="\\t"}} {{ if($4>={params.mappability}) print $1,$2,$3 }}' {input.map} > {params.TEMP_map}
+        bedtools intersect -a {params.TEMP_cov} -b {params.TEMP_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites}
+        rm {params.TEMP_cov}
+        rm {params.TEMP_map}
+        """

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -153,7 +153,7 @@ rule callable_bed:
         TEMP_map = config['tmp_dir'] + "{Organism}_{refGenome}_TEMP.map.bed"
     shell:
         "bedtools merge {input.callable_cov} > {params.TEMP_cov}"
-        """awk 'BEGIN{OFS="\\t";FS="\\t"} { if($4>={params.mappability}) print $1,$2,$3 }' {input.map} > {params.TEMP_map}"""
+        """awk 'BEGIN{{OFS="\\t";FS="\\t"}} {{ if($4>={params.mappability}) print $1,$2,$3 }}' {input.map} > {params.TEMP_map}"""
         "bedtools intersect -a {params.TEMP_cov} -b {params.TEMP_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites}"
         "rm {params.TEMP_cov}"
         "rm {params.TEMP_map}"

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -111,7 +111,7 @@ rule create_cov_bed:
     conda:
         "../envs/callable.yml"
     script:
-        "scripts/create_coverage_bed.py"
+        "../scripts/create_coverage_bed.py"
 
 rule callable_bed:
     input:

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -130,8 +130,8 @@ rule callable_bed:
         TEMP_cov = config['tmp_dir'] + "{Organism}_{refGenome}_TEMP.cov.bed",
         TEMP_map = config['tmp_dir'] + "{Organism}_{refGenome}_TEMP.map.bed"
     shell:
-        "bedtools merge {input.callable_cov} > {params.TEMP_cov}"
-        """awk 'BEGIN{{OFS="\\t";FS="\\t"}} {{ if($4>={params.mappability}) print $1,$2,$3 }}' {input.map} > {params.TEMP_map}"""
-        "bedtools intersect -a {params.TEMP_cov} -b {params.TEMP_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites}"
-        "rm {params.TEMP_cov}"
-        "rm {params.TEMP_map}"
+        "bedtools merge {input.cov} > {params.TEMP_cov} "
+        """awk 'BEGIN{{OFS="\\t";FS="\\t"}} {{ if($4>={params.mappability}) print $1,$2,$3 }}' {input.map} > {params.TEMP_map} """
+        "bedtools intersect -a {params.TEMP_cov} -b {params.TEMP_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites} "
+        "rm {params.TEMP_cov} "
+        "rm {params.TEMP_map} "

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -61,7 +61,7 @@ rule compute_d4:
         bam = config['output'] + "{Organism}/{refGenome}/" + config['bamDir'] + "{sample}" + config['bam_suffix']
     output:
         config['output'] + "{Organism}/{refGenome}/" + config['sumstatDir'] + "{sample}.mosdepth.global.dist.txt",
-        temp(config['output'] + "{Organism}/{refGenome}/" + config['sumstatDir'] + "{sample}.per-base.bed.gz"),
+        temp(config['output'] + "{Organism}/{refGenome}/" + config['sumstatDir'] + "{sample}.per-base.d4"),
         summary=config['output'] + "{Organism}/{refGenome}/" + config['sumstatDir'] + "{sample}.mosdepth.summary.txt"
     conda:
         "../envs/callable.yml"
@@ -106,8 +106,6 @@ rule create_cov_bed:
         d4 = config['output'] + "{Organism}/{refGenome}/{refGenome}_{Organism}.d4"
     output:
         covbed = temp(config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".callable_sites_cov.bed")
-    conda:
-        "../envs/callable.yml"
     params:
         mappability = config['mappability_min'],
         cov_threshold = config['cov_threshold']
@@ -155,7 +153,7 @@ rule callable_bed:
         TEMP_map = config['tmp_dir'] + "{Organism}_{refGenome}_TEMP.map.bed"
     shell:
         "bedtools merge {input.callable_cov} > {params.TEMP_cov}"
-        "awk 'BEGIN{OFS="\t";FS="\t"} { if($4>={params.mappability}) print $1,$2,$3 }' {input.map} > {params.TEMP_map}"
+        """awk 'BEGIN{OFS="\\t";FS="\\t"} { if($4>={params.mappability}) print $1,$2,$3 }' {input.map} > {params.TEMP_map}"""
         "bedtools intersect -a {params.TEMP_cov} -b {params.TEMP_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites}"
         "rm {params.TEMP_cov}"
         "rm {params.TEMP_map}"

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -1,6 +1,3 @@
-import gzip
-import json
-
 localrules: genome_prep
 
 ## RULES ##
@@ -56,121 +53,109 @@ rule genome_prep:
   conda:
       "../envs/callable.yml"
   shell:
-      "faToTwoBit {input.ref} {output.twobit}\n"
+      "faToTwoBit {input.ref} {output.twobit}"
       "twoBitInfo {output.twobit} stdout | sort -k2rn > {output.chrom}"
 
-rule bedgraphs:
+rule compute_d4:
     input:
         bam = config['output'] + "{Organism}/{refGenome}/" + config['bamDir'] + "{sample}" + config['bam_suffix']
     output:
-        temp(config['output'] + "{Organism}/{refGenome}/" + config['bamDir'] + "preMerge/{sample}.sorted.bg")
+        config['output'] + "{Organism}/{refGenome}/" + config['sumstatDir'] + "{sample}.mosdepth.global.dist.txt",
+        temp(config['output'] + "{Organism}/{refGenome}/" + config['sumstatDir'] + "{sample}.per-base.bed.gz"),
+        summary=config['output'] + "{Organism}/{refGenome}/" + config['sumstatDir'] + "{sample}.mosdepth.summary.txt"
     conda:
         "../envs/callable.yml"
     benchmark:
         "benchmarks/{Organism}/bedgraphs/{refGenome}_{Organism}_{sample}.txt"
     resources:
-        mem_mb = lambda wildcards, attempt: attempt * res_config['bedtools']['mem']
+        mem_mb = lambda wildcards, attempt: attempt * res_config['compute_d4']['mem']
+    threads:
+        res_config['compute_d4']['threads']
+    params:
+        prefix = config['output'] + "{Organism}/{refGenome}/" + config['sumstatDir'] + "{sample}"
     shell:
-        "bedtools genomecov -ibam {input.bam} -bga | sort -k1,1 -k2,2n - > {output}"
+        "mosdepth --d4 -t {threads} {params.prefix} {input.bam}"
 
-rule merge_bedgraph:
+rule merge_d4:
     input:
         unpack(get_input_for_coverage)
     output:
-        merge = temp(config['output'] + "{Organism}/{refGenome}/" + config['bamDir'] + "postMerge/{Organism}.merge.bg")
+        config['output'] + "{Organism}/{refGenome}/{refGenome}_{Organism}.d4"
     benchmark:
-        "benchmarks/{Organism}/merge_begraph/{refGenome}_{Organism}.txt"
+        "benchmarks/{Organism}/merge_d4/{refGenome}_{Organism}.txt"
     conda:
         "../envs/callable.yml"
     resources:
-        mem_mb = lambda wildcards, attempt: attempt * res_config['bedtools']['mem']
+        mem_mb = lambda wildcards, attempt: attempt * res_config['merge_d4']['mem']
     shell:
-        "bedtools unionbedg -header -empty -g {input.chrom} -i {input.bedgraphs} > {output.merge}"
-
-rule gzip_bedgraph:
-    input:
-        get_bedgraph_to_convert
-    output:
-        bgz = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".bg.gz",
-        idx = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".bg.gzi"
-    conda:
-        "../envs/callable.yml"
-    shell:
-        "bgzip -i -I {output.idx} -c {input} > {output.bgz}"
+        "d4tools merge {input.d4files} {output}"
 
 rule compute_covstats:
     input:
-        bgz = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".bg.gz"
+        d4 = config['output'] + "{Organism}/{refGenome}/{refGenome}_{Organism}.d4"
     output:
-        cov = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".covstats.bg.gz",
         stats = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".covstats.txt"
-    run:
-        covtot = 0.0
-        meantot = 0.0
-        bptot = 0.0
-        with gzip.open(input.bgz, 'rt') as f:
-            with gzip.open(output.cov, 'wt') as covbed:
-                for line in f:
-                    fields = line.split()
-                    if (len(fields) < 4):
-                        continue
-                    try:
-                        cov_fields = map(float, fields[3:])
-                    except:
-                        continue
-                    covsum = sum(cov_fields)
-                    mean = covsum / len(fields[3:])
-                    bp = float(fields[2]) - float(fields[1])
-                    covtot = covtot + (covsum * bp)
-                    meantot = meantot + (mean * bp)
-                    bptot = bptot + bp
-                    print(fields[0], fields[1], fields[2], covsum, mean, file=covbed, sep="\t")
-        stats = {"mean_summed_cov": covtot/bptot, "mean_ind_cov": meantot / bptot}
-        with open(output.stats, 'w') as st:
-            print(json.dumps(stats), file=st)
+    conda:
+        "../envs/callable.yml"
+    shell:
+        "d4tools stat {input.d4} | awk '{ for(i=4; i<=NF;i++) j+=$i; print $1,$3,j; j=0 }' > {output}"
 
-rule filter_bed:
+rule create_cov_bed:
     input:
-        cov = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".covstats.bg.gz",
-        map = config['output'] + "{refGenome}/" + "genmap/{refGenome}.sorted_genmap.bg",
-        stats = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".covstats.txt"
+        stats = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".covstats.txt",
+        d4 = config['output'] + "{Organism}/{refGenome}/{refGenome}_{Organism}.d4"
     output:
-        callable_cov = temp(config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".callable_sites_cov.bed"),
-        callable_map = temp(config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".callable_sites_map.bed")
+        covbed = temp(config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".callable_sites_cov.bed")
+    conda:
+        "../envs/callable.yml"
     params:
         mappability = config['mappability_min'],
-        low_cov = config['low_cov_thresh'],
-        high_cov = config['high_cov_thresh'],
-        cov_type = config['cov_type']
+        cov_threshold = config['cov_threshold']
     run:
-        stats = {}
+        from pyd4 import D4File,D4Builder
+        import math
+
+        #read chrom coverage values and compute min/max
+        cov_thresh = {}
+        stdv_scale = float(params.cov_threshold)
         with open(input.stats) as stats:
-            stats = json.load(stats)
-        min_cov = float(stats[params.cov_type]) * params.low_cov
-        max_cov = float(stats[params.cov_type]) * params.high_cov
-        record_num = 3 if params.cov_type == "mean_summed_cov" else 4
-        with gzip.open(input.cov, 'rt') as cov:
-            with open(output.callable_cov, 'w') as cov_out:
-                for line in cov:
-                    fields = line.split()
-                    if float(fields[record_num]) >= min_cov and float(fields[record_num]) <= max_cov:
-                        print(fields[0], fields[1], fields[2], sep="\t", file=cov_out)
-        with open(input.map) as map:
-            with open(output.callable_map, 'w') as map_out:
-                for line in map:
-                    fields=line.split()
-                    if float(fields[3]) >= params.mappability:
-                        print(fields[0], fields[1], fields[2], sep="\t", file=map_out)
+            for line in stats:
+                fields=line.split()
+                stdev = math.sqrt(float(fields[1]))
+                cov_thresh[fields[0]] = {'low' : float(fields[2]) - (stdev * stdv_scale),
+                    'high' : float(fields[2]) + (stdev * stdv_scale)}
+
+        #read d4 file into python, convert to
+        covfile = D4File(input.d4)
+        covmat = covfile.open_all_tracks()
+
+        with open(output.covbed, mode='w') as covbed:
+            for chrom in covfile.chroms():
+                for values in covmat.enumerate_values(chrom[0],0,chrom[1]):
+                    covs=values[2]
+                    res1=math.fsum(covs)
+                    if res1 <= cov_thresh[chrom[0]]['high'] and res1 >= cov_thresh[chrom[0]]['low']:
+                        print(chrom[0], values[1])
 
 rule callable_bed:
     input:
-        callable_cov = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".callable_sites_cov.bed",
-        callable_map = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".callable_sites_map.bed"
+        cov = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".callable_sites_cov.bed",
+        map = config['output'] + "{refGenome}/" + "genmap/{refGenome}.sorted_genmap.bg"
     output:
         callable_sites = config['output'] + "{Organism}/{refGenome}/" + "{Organism}_{refGenome}" + ".callable_sites.bed"
     conda:
         "../envs/callable.yml"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * res_config['callable_bed']['mem']
     params:
-        merge = config['callable_merge']
+        merge = config['callable_merge'],
+        mappability = config['mappability_min'],
+        #possibly better ways to create temp files in snakemake but this will work for now
+        TEMP_cov = config['tmp_dir'] + "{Organism}_{refGenome}_TEMP.cov.bed",
+        TEMP_map = config['tmp_dir'] + "{Organism}_{refGenome}_TEMP.map.bed"
     shell:
-        "bedtools intersect -a {input.callable_cov} -b {input.callable_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites}"
+        "bedtools merge {input.callable_cov} > {params.TEMP_cov}"
+        "awk 'BEGIN{OFS="\t";FS="\t"} { if($4>={params.mappability}) print $1,$2,$3 }' {input.map} > {params.TEMP_map}"
+        "bedtools intersect -a {params.TEMP_cov} -b {params.TEMP_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites}"
+        "rm {params.TEMP_cov}"
+        "rm {params.TEMP_map}"

--- a/workflow/rules/callable_sites.smk
+++ b/workflow/rules/callable_sites.smk
@@ -131,7 +131,7 @@ rule callable_bed:
         TEMP_map = config['tmp_dir'] + "{Organism}_{refGenome}_TEMP.map.bed"
     shell:
         """
-        bedtools merge {input.cov} > {params.TEMP_cov}
+        bedtools merge -i {input.cov} > {params.TEMP_cov}
         awk 'BEGIN{{OFS="\\t";FS="\\t"}} {{ if($4>={params.mappability}) print $1,$2,$3 }}' {input.map} > {params.TEMP_map}
         bedtools intersect -a {params.TEMP_cov} -b {params.TEMP_map} | bedtools sort -i - | bedtools merge -d {params.merge} -i - > {output.callable_sites}
         rm {params.TEMP_cov}

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -129,9 +129,8 @@ def get_bedgraph_to_convert(wildcards):
 def get_input_for_coverage(wildcards):
     # Gets the correct sample given the organism and reference genome for the bedgraph merge step
     _samples = samples.loc[(samples['Organism'] == wildcards.Organism) & (samples['refGenome'] == wildcards.refGenome)]['BioSample'].tolist()
-    bedgraphFiles = expand(config['output'] + "{{Organism}}/{{refGenome}}/" + config['bamDir'] + "preMerge/{sample}" + ".sorted.bg", sample=_samples)
-    chromFile = config['output'] + "{refGenome}/" + "{refGenome}" + ".sizes"
-    return {'bedgraphs': bedgraphFiles, 'chrom': chromFile}
+    d4files = expand(config['output'] + "{{Organism}}/{{refGenome}}/" + config['sumstatsDir'] + "{sample}" + ".d4", sample=_samples)
+    return {'d4files': d4files}}
 
 def make_intervals(outputDir, intDir, wildcards, dict_file, max_intervals):
     """Creates interval list files for parallelizing haplotypeCaller and friends. Writes one contig/chromosome per list file."""

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -119,18 +119,11 @@ def get_input_for_mapfile(wildcards):
 
     return {'gvcfs': gvcfs, 'gvcfs_idx': gvcfs_idx, 'doneFiles': doneFiles}
 
-def get_bedgraph_to_convert(wildcards):
-    _samples = samples.loc[(samples['Organism'] == wildcards.Organism) & (samples['refGenome'] == wildcards.refGenome)]['BioSample'].unique().tolist()
-    if len(_samples) == 1:
-        return expand(config['output'] + "{{Organism}}/{{refGenome}}/" + config['bamDir'] + "preMerge/{sample}.sorted.bg", sample=_samples)
-    else:
-        return config['output'] + "{Organism}/{refGenome}/" + config['bamDir'] + "postMerge/{Organism}.merge.bg"
-
 def get_input_for_coverage(wildcards):
     # Gets the correct sample given the organism and reference genome for the bedgraph merge step
     _samples = samples.loc[(samples['Organism'] == wildcards.Organism) & (samples['refGenome'] == wildcards.refGenome)]['BioSample'].tolist()
-    d4files = expand(config['output'] + "{{Organism}}/{{refGenome}}/" + config['sumstatsDir'] + "{sample}" + ".d4", sample=_samples)
-    return {'d4files': d4files}}
+    d4files = expand(config['output'] + "{{Organism}}/{{refGenome}}/" + config['sumstatDir'] + "{sample}" + ".per-base.d4", sample=_samples)
+    return {'d4files': d4files}
 
 def make_intervals(outputDir, intDir, wildcards, dict_file, max_intervals):
     """Creates interval list files for parallelizing haplotypeCaller and friends. Writes one contig/chromosome per list file."""

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -19,6 +19,7 @@ def get_ref(wildcards):
         return _refs
     else:
         return []
+        
 def get_ena_url(wildcards):
     prefix = wildcards.run[:6]
     lastdigit = wildcards.run[-1]

--- a/workflow/rules/fastq2bam.smk
+++ b/workflow/rules/fastq2bam.smk
@@ -52,15 +52,13 @@ rule download_reference:
     params:
         dataset = config["refGenomeDir"] + "{refGenome}_dataset.zip",
         outdir = config["refGenomeDir"] + "{refGenome}"
-    log:
-        "logs/dl_reference/{refGenome}.log"
     conda:
         "../envs/fastq2bam.yml"
     shell:
         """
         if [ -z "{input.ref}" ]  # check if this is empty
         then
-            datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {params.dataset} {wildcards.refGenome} &> {log} \
+            datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {params.dataset} {wildcards.refGenome} \
             && 7z x {params.dataset} -aoa -o{params.outdir} \
             && cat {params.outdir}/ncbi_dataset/data/{wildcards.refGenome}/*.fna > {output.ref}
         else

--- a/workflow/rules/fastq2bam.smk
+++ b/workflow/rules/fastq2bam.smk
@@ -22,8 +22,11 @@ rule get_fastq_pe:
         """
         set +e
 
-        ##attempt to get SRA file from NCIB (prefetch) or ENA (wget)
-        prefetch --max-size u {wildcards.run}
+        #delete existing prefetch file in case of previous run failure
+        rm -rf {wildcards.run}
+
+        ##attempt to get SRA file from NCBI (prefetch) or ENA (wget)
+        prefetch --max-size 1T {wildcards.run}
         prefetchExit=$?
         if [[ $prefetchExit -ne 0 ]]
         then
@@ -55,7 +58,6 @@ rule download_reference:
         "../envs/fastq2bam.yml"
     shell:
         """
-
         if [ -z "{input.ref}" ]  # check if this is empty
         then
             datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {params.dataset} {wildcards.refGenome} &> {log} \

--- a/workflow/rules/fastq2bam.smk
+++ b/workflow/rules/fastq2bam.smk
@@ -23,7 +23,7 @@ rule get_fastq_pe:
         set +e
 
         ##attempt to get SRA file from NCIB (prefetch) or ENA (wget)
-        prefetch {wildcards.run}
+        prefetch --max-size u {wildcards.run}
         prefetchExit=$?
         if [[ $prefetchExit -ne 0 ]]
         then
@@ -55,7 +55,7 @@ rule download_reference:
         "../envs/fastq2bam.yml"
     shell:
         """
-        
+
         if [ -z "{input.ref}" ]  # check if this is empty
         then
             datasets download genome accession --exclude-gff3 --exclude-protein --exclude-rna --filename {params.dataset} {wildcards.refGenome} &> {log} \

--- a/workflow/rules/intervals.smk
+++ b/workflow/rules/intervals.smk
@@ -27,7 +27,8 @@ checkpoint create_intervals:
         maxBpPerList = lambda wildcards, resources: resources.attempt * int(config['maxBpPerList']),
         maxIntervalsPerList = int(config['maxIntervalsPerList']),
         minNmer = int(config['minNmer']),
-        max_intervals = config['maxNumIntervals']
+        max_intervals = config['maxNumIntervals'],
+        missingBpTolerance = config['missingBpTolerance']
     output:
         config['output'] + "{Organism}/{refGenome}/" + config["intDir"] + "{refGenome}_intervals_fb.bed"
     resources:
@@ -35,6 +36,6 @@ checkpoint create_intervals:
         attempt = lambda wildcards, attempt: attempt
     run:
         if config['split_by_n']:
-            LISTS = helperFun.createListsGetIndices(params.maxIntervalLen, params.maxBpPerList, params.maxIntervalsPerList, params.minNmer, config["output"], config["intDir"], wildcards, input.dictf, input.intervals)
+            LISTS = helperFun.createListsGetIndices(params.missingBpTolerance, params.maxIntervalLen, params.maxBpPerList, params.maxIntervalsPerList, params.minNmer, config["output"], config["intDir"], wildcards, input.dictf, input.intervals)
         else:
             LISTS = make_intervals(config["output"], config["intDir"], wildcards, input.dictf, params.max_intervals)

--- a/workflow/scripts/create_coverage_bed.py
+++ b/workflow/scripts/create_coverage_bed.py
@@ -21,4 +21,4 @@ with open(snakemake.output["covbed"], mode='w') as covbed:
             covs=values[2]
             res1=math.fsum(covs)
             if res1 <= cov_thresh[chrom[0]]['high'] and res1 >= cov_thresh[chrom[0]]['low']:
-                print(chrom[0], values[1], values[1]+1, file=covbed)
+                print(chrom[0], values[1], values[1]+1, file=covbed, sep="\t")

--- a/workflow/scripts/create_coverage_bed.py
+++ b/workflow/scripts/create_coverage_bed.py
@@ -1,0 +1,24 @@
+from pyd4 import D4File,D4Builder
+import math
+
+#read chrom coverage values and compute min/max
+cov_thresh = {}
+stdv_scale = float(snakemake.params["cov_threshold"])
+with open(snakemake.input["stats"]) as stats:
+    for line in stats:
+        fields=line.split()
+        stdev = math.sqrt(float(fields[1]))
+        cov_thresh[fields[0]] = {'low' : float(fields[2]) - (stdev * stdv_scale),
+            'high' : float(fields[2]) + (stdev * stdv_scale)}
+
+#read d4 file into python, convert to
+covfile = D4File(snakemake.input["d4"])
+covmat = covfile.open_all_tracks()
+
+with open(snakemake.output["covbed"], mode='w') as covbed:
+    for chrom in covfile.chroms():
+        for values in covmat.enumerate_values(chrom[0],0,chrom[1]):
+            covs=values[2]
+            res1=math.fsum(covs)
+            if res1 <= cov_thresh[chrom[0]]['high'] and res1 >= cov_thresh[chrom[0]]['low']:
+                print(chrom[0], values[1])

--- a/workflow/scripts/create_coverage_bed.py
+++ b/workflow/scripts/create_coverage_bed.py
@@ -21,4 +21,4 @@ with open(snakemake.output["covbed"], mode='w') as covbed:
             covs=values[2]
             res1=math.fsum(covs)
             if res1 <= cov_thresh[chrom[0]]['high'] and res1 >= cov_thresh[chrom[0]]['low']:
-                print(chrom[0], values[1], file=covbed)
+                print(chrom[0], values[1], values[1]+1, file=covbed)

--- a/workflow/scripts/create_coverage_bed.py
+++ b/workflow/scripts/create_coverage_bed.py
@@ -21,4 +21,4 @@ with open(snakemake.output["covbed"], mode='w') as covbed:
             covs=values[2]
             res1=math.fsum(covs)
             if res1 <= cov_thresh[chrom[0]]['high'] and res1 >= cov_thresh[chrom[0]]['low']:
-                print(chrom[0], values[1])
+                print(chrom[0], values[1], file=covbed)


### PR DESCRIPTION
This pull request changes the way we do coverage calculations, to use mosdepth and d4tools instead of relying on bedtools unionbedgraph, which can be very slow for large sets.