### PR TITLE
Fix conda envs

### DIFF
--- a/workflow/envs/callable.yml
+++ b/workflow/envs/callable.yml
@@ -1,20 +1,20 @@
 channels:
+  - conda-forge
   - bioconda
   - defaults
-  - conda-forge
 dependencies:
   - bedtools==2.30.0
   - htslib==1.14
   - ucsc-fatotwobit==377
   - ucsc-twobitinfo==377
   - ucsc-bedtobigbed==377
-  - genmap>=1.3.0
-  - mosdepth>=0.3.3
-  - d4tools>=0.3.4
-  - pip
-  - rust
-  - gcc
-  - binutils
-  - make
+  - genmap==1.3.0
+  - mosdepth==0.3.3
+  - d4tools==0.3.4
+  - pip==22.0.4
+  - rust==1.60.0
+  - gcc==11.2.0
+  - binutils==2.36.1
+  - make==4.3
   - pip:
-      - pyd4
+      - pyd4==0.3.6

--- a/workflow/envs/fastq2bam.yml
+++ b/workflow/envs/fastq2bam.yml
@@ -1,13 +1,13 @@
 channels:
+  - conda-forge
   - bioconda
   - defaults
-  - conda-forge
 dependencies:
-  - samtools>=1.14
+  - samtools==1.14
   - fastp==0.20.1
-  - bwa=0.7.17
+  - bwa==0.7.17
   - sra-tools==2.10.1
   - ncbi-datasets-cli==11.25.1
   - p7zip==16.02
-  - pigz
-  - wget
+  - pigz==2.6
+  - wget==1.20.3

--- a/workflow/envs/sambamba.yml
+++ b/workflow/envs/sambamba.yml
@@ -1,7 +1,6 @@
 channels:
+  - conda-forge
   - bioconda
   - defaults
-  - conda-forge
 dependencies:
-  - sambamba
-
+  - sambamba==0.8.0


### PR DESCRIPTION
This pull request makes sure that conda-forge is listed first in the channels, and pins versions of all tools. 