### PR TITLE
Update qc.yml

### DIFF
--- a/workflow/modules/qc/envs/qc.yml
+++ b/workflow/modules/qc/envs/qc.yml
@@ -17,3 +17,4 @@ dependencies:
   - r-reshape2==1.4.4
   - bioconductor-ggtree==3.2.0
   - r-ggmap=3.0.0
+  - r-ggplot2=3.3.5


### PR DESCRIPTION
QC test errors 
```
Quitting from lines 340-391 (qc_dashboard_interactive.Rmd)  Error in `stat_tree()`:
! Problem while converting geom to grob.
â„¹ Error occurred in the 1st layer.
Caused by error in `check.length()`:
! 'gpar' element 'lwd' must not be length 0
```

Is due to ggplot2 3.4.0 update has a bug. Solving by explicitly defining ggplot 3.3.5 in qc plots. Apparently tidyverse=1.3.1 is not sufficient for version control