### PR TITLE
fix QC R dependencies 

### DIFF
--- a/workflow/modules/qc/Snakefile
+++ b/workflow/modules/qc/Snakefile
@@ -33,7 +33,7 @@ rule vcftools_individuals:
         summ = "results/{refGenome}/QC/{prefix}.FILTER.summary",
         het = "results/{refGenome}/QC/{prefix}.het"
     conda:
-        "envs/qc.yml"
+        "envs/vcftools_individuals.yml"
     params:
         prefix = lambda wc, input: os.path.join(input.vcf.rsplit("/", 1)[0], "QC", wc.prefix),
         min_depth = config["min_depth"]
@@ -52,7 +52,6 @@ rule subsample_snps:
         samps = "results/{refGenome}/QC/{prefix}.samps.txt",
         fai = "results/{refGenome}/data/genome/{refGenome}.fna.fai",
         sumstats = "results/{refGenome}/summary_stats/{prefix}_bam_sumstats.txt"
-
     output:
         filtered = "results/{refGenome}/QC/{prefix}_filtered.vcf.gz",
         filtered_idx = "results/{refGenome}/QC/{prefix}_filtered.vcf.gz.csi",
@@ -61,8 +60,7 @@ rule subsample_snps:
         fai = "results/{refGenome}/QC/{prefix}.fna.fai",
         sumstats = "results/{refGenome}/QC/{prefix}_bam_sumstats.txt"
     conda:
-        "envs/qc.yml"
-    
+        "envs/subsample_snps.yml"
     shell:
         """
         ##first remove filtered sites and retain only biallelic SNPs
@@ -107,10 +105,8 @@ rule plink:
         dist = "results/{refGenome}/QC/{prefix}.dist",
         distid = "results/{refGenome}/QC/{prefix}.dist.id",
         king = "results/{refGenome}/QC/{prefix}.king"
-
-  
     conda:
-        "envs/qc.yml"
+        "envs/plink.yml"
     shell:
         #plink 2 for king relatedness matrix (robust to structure) and plink 1.9 for distance matrix
         """
@@ -131,9 +127,8 @@ rule admixture:
         admix2 = "results/{refGenome}/QC/{prefix}.2.Q"
     params:
         outdir = lambda wc, input: input.bed.rsplit("/", 1)[0]
-
     conda:
-        "envs/qc.yml"
+        "envs/admixture.yml"
     shell:
         """
         mv {input.bim} {input.bim}.orig
@@ -185,7 +180,6 @@ rule qc_plots:
         GMKey = config['GoogleAPIKey']
     output: 
         qcpdf = "results/{refGenome}/QC/{prefix}_qc.html"
-  
     conda:
         "envs/qc.yml"
     script:

--- a/workflow/modules/qc/envs/admixture.yml
+++ b/workflow/modules/qc/envs/admixture.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - admixture==1.3.0

--- a/workflow/modules/qc/envs/plink.yml
+++ b/workflow/modules/qc/envs/plink.yml
@@ -1,0 +1,7 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - plink2==2.00a2.3
+  - plink==1.90b6.21

--- a/workflow/modules/qc/envs/qc.yml
+++ b/workflow/modules/qc/envs/qc.yml
@@ -1,7 +1,9 @@
 channels:
+  - conda-forge
   - bioconda
+  - defaults
 dependencies:
-  - r-base==4.1.1
+  - r-base==4.1.3
   - r-tidyverse==1.3.1
   - r-plotly==4.9.4.1
   - r-flexdashboard==0.5.2

--- a/workflow/modules/qc/envs/qc.yml
+++ b/workflow/modules/qc/envs/qc.yml
@@ -1,14 +1,6 @@
 channels:
-  - conda-forge
   - bioconda
-  - defaults
 dependencies:
-  - plink2==2.00a2.3
-  - plink==1.90b6.21
-  - admixture==1.3.0
-  - bedtools==2.29.2
-  - bcftools==1.12
-  - vcftools==0.1.16
   - r-base==4.1.1
   - r-tidyverse==1.3.1
   - r-plotly==4.9.4.1

--- a/workflow/modules/qc/envs/subsample_snps.yml
+++ b/workflow/modules/qc/envs/subsample_snps.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bcftools==1.12

--- a/workflow/modules/qc/envs/vcftools_individuals.yml
+++ b/workflow/modules/qc/envs/vcftools_individuals.yml
@@ -1,0 +1,6 @@
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - vcftools==0.1.16

--- a/workflow/rules/fastq.smk
+++ b/workflow/rules/fastq.smk
@@ -26,7 +26,13 @@ rule get_fastq_pe:
             ffq --ftp {wildcards.run} | grep -Eo '"url": "[^"]*"' | grep -o '"[^"]*"$' | grep "fastq" | xargs curl --remote-name-all --output-dir {params.outdir}
         else
             fasterq-dump {wildcards.run} -O {params.outdir} -e {threads} -t {resources.tmpdir}
-            pigz -p {threads} {params.outdir}{wildcards.run}*.fastq
+            if [[ ! -f  {params.outdir}{wildcards.run}_1.fastq ]]
+            then
+                fastq-dump {wildcards.run} -O {params.outdir} --split-files
+                pigz -p {threads} {params.outdir}{wildcards.run}*.fastq
+            else
+                pigz -p {threads} {params.outdir}{wildcards.run}*.fastq
+            fi
         fi
         rm -rf {wildcards.run}
         """


### PR DESCRIPTION
The environment building started to fail for the QC module. 

Running QC test like so:

`snakemake -d .test/qc --use-conda --cores 10 -s workflow/modules/qc/Snakefile`

resulted in: 

```
Building DAG of jobs...
Your conda installation is not configured to use strict channel priorities. This is however crucial for having robust and correct environments (for details, see https://conda-forge.org/docs/user/tipsandtricks.html). Please consider to configure strict priorities by executing 'conda config --set channel_priority strict'.
Creating conda environment /data/snpArcher/workflow/modules/qc/envs/qc.yml...
Downloading and installing remote packages.
CreateCondaEnvironmentException:
Could not create conda environment from /data/snpArcher/workflow/modules/qc/envs/qc.yml:
Command:
mamba env create --quiet --file "/data/snpArcher/.test/qc/.snakemake/conda/9ec289de8e88dc89e086c8afaeb5b696_.yaml" --prefix "/data/snpArcher/.test/qc/.snakemake/conda/9ec289de8e88dc89e086c8afaeb5b696_"
Output:
Encountered problems while solving:
  - package r-base-4.1.1-hb67fd72_0 requires libxml2 >=2.9.12,<2.11.0a0, but none of the providers can be installed
 ```

I ran the github tests and received the same error. 

It is very confusing, this should not happen but as near as I can tell the r-base 4.1.1 on conda-forge became non-functional. We were past time to split up conda environments per rule which QC especially needs, so I have done that in this commit. 

I saw that 4.1.3 had recently been patched on conda as it was the most recently updated:
https://anaconda.org/conda-forge/r-base/files

So I switched to this and it passed test


