### PR TITLE
Add min_version

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -1,3 +1,6 @@
+from snakemake.utils import min_version
+min_version("7.0")
+
 configfile: "config/config.yaml"
 include: "rules/common.smk"
 include: "rules/sumstats.smk"


### PR DESCRIPTION
This is a small PR to add a minimum version to snpArcher for easier debugging. Will prevent `Unexpected keyword default_target in rule definition (Snakefile, line 37)` errors.