### PR TITLE
Production ready Sentieon

### DIFF
--- a/workflow/rules/sentieon.smk
+++ b/workflow/rules/sentieon.smk
@@ -3,8 +3,8 @@ rule sentieon_map:
         ref = "results/{refGenome}/data/genome/{refGenome}.fna",
         r1 = "results/{refGenome}/filtered_fastqs/{sample}/{run}_1.fastq.gz",
         r2 = "results/{refGenome}/filtered_fastqs/{sample}/{run}_2.fastq.gz",
-        indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"]),
-        lic = ancient(config['sentieon_lic'])
+        indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"])
+        #lic = ancient(config['sentieon_lic'])
     output: 
         bam = temp("results/{refGenome}/bams/preMerge/{sample}/{run}.bam"),
         bai = temp("results/{refGenome}/bams/preMerge/{sample}/{run}.bam.bai"),
@@ -46,8 +46,8 @@ rule merge_bams:
 
 rule sentieon_dedup:
     input:
-        unpack(dedup_input),
-        lic = ancient(config['sentieon_lic']),
+        unpack(dedup_input)
+        #lic = ancient(config['sentieon_lic']),
     output:
         dedupBam = "results/{refGenome}/bams/{sample}_final.bam",
         dedupBai = "results/{refGenome}/bams/{sample}_final.bam.bai",
@@ -77,8 +77,8 @@ rule sentieon_haplotyper:
         indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"]),
         dictf = "results/{refGenome}/data/genome/{refGenome}.dict",
         bam = "results/{refGenome}/bams/{sample}_final.bam",
-        bai = "results/{refGenome}/bams/{sample}_final.bam.bai",
-        lic = ancient(config['sentieon_lic'])
+        bai = "results/{refGenome}/bams/{sample}_final.bam.bai"
+        #lic = ancient(config['sentieon_lic'])
     output:
         gvcf = "results/{refGenome}/gvcfs/{sample}.g.vcf.gz",
         gvcf_idx = "results/{refGenome}/gvcfs/{sample}.g.vcf.gz.tbi",
@@ -103,8 +103,8 @@ rule sentieon_combine_gvcf:
         unpack(sentieon_combine_gvcf_input),
         ref = "results/{refGenome}/data/genome/{refGenome}.fna",
         indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"]),
-        dictf = "results/{refGenome}/data/genome/{refGenome}.dict",
-        lic = ancient(config['sentieon_lic']),
+        dictf = "results/{refGenome}/data/genome/{refGenome}.dict"
+        #lic = ancient(config['sentieon_lic']),
     output:
         vcf = temp("results/{refGenome}/vcfs/raw.vcf.gz"),
         tbi = temp("results/{refGenome}/vcfs/raw.vcf.gz.tbi")

--- a/workflow/rules/sentieon.smk
+++ b/workflow/rules/sentieon.smk
@@ -110,7 +110,7 @@ rule sentieon_combine_gvcf:
         vcf = temp("results/{refGenome}/vcfs/raw.vcf.gz"),
         tbi = temp("results/{refGenome}/vcfs/raw.vcf.gz.tbi")
     params:
-        lambda wc, input: " ".join(["-v " + gvcf for gvcf in input['gvcfs']]),
+        glist = lambda wc, input: " ".join(["-v " + gvcf for gvcf in input['gvcfs']]),
         lic = config['sentieon_lic']
     threads: resources['sentieon_combine_gvcf']['threads']
     resources:
@@ -126,7 +126,7 @@ rule sentieon_combine_gvcf:
     shell:
         """
         export SENTIEON_LICENSE={params.lic}
-        sentieon driver -r {input.ref} -t {threads} --algo GVCFtyper --emit_mode VARIANT {output.vcf} {params} 2> {log}
+        sentieon driver -r {input.ref} -t {threads} --algo GVCFtyper --emit_mode VARIANT {output.vcf} {params.glist} 2> {log}
         """
 
 rule filter_vcf:

--- a/workflow/rules/sumstats.smk
+++ b/workflow/rules/sumstats.smk
@@ -22,7 +22,8 @@ rule sentieon_bam_stats:
         bai = "results/{refGenome}/bams/{sample}_final.bam.bai",
         indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"]),
         ref = "results/{refGenome}/data/genome/{refGenome}.fna"
-        #lic = ancient(config['sentieon_lic'])
+    params:
+        lic = config['sentieon_lic']
     output:
         insert_file = "results/{refGenome}/summary_stats/{sample}_insert_metrics.txt",
         qd = "results/{refGenome}/summary_stats/{sample}_qd_metrics.txt",
@@ -33,7 +34,7 @@ rule sentieon_bam_stats:
         "../envs/sentieon.yml"
     shell:
         """
-        export SENTIEON_LICENSE={input.lic}
+        export SENTIEON_LICENSE={params.lic}
         sentieon driver -r {input.ref} \
         -t {threads} -i {input.bam} \
         --algo MeanQualityByCycle {output.mq} \

--- a/workflow/rules/sumstats.smk
+++ b/workflow/rules/sumstats.smk
@@ -21,8 +21,8 @@ rule sentieon_bam_stats:
         bam = "results/{refGenome}/bams/{sample}_final.bam",
         bai = "results/{refGenome}/bams/{sample}_final.bam.bai",
         indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"]),
-        ref = "results/{refGenome}/data/genome/{refGenome}.fna",
-        lic = ancient(config['sentieon_lic'])
+        ref = "results/{refGenome}/data/genome/{refGenome}.fna"
+        #lic = ancient(config['sentieon_lic'])
     output:
         insert_file = "results/{refGenome}/summary_stats/{sample}_insert_metrics.txt",
         qd = "results/{refGenome}/summary_stats/{sample}_qd_metrics.txt",


### PR DESCRIPTION
We originally set up the sentieon module to run with a trial license file. Production Sentieon licenses run by pinging a license on a server somewhere. This is the standard mode for running Sentieon, so I suggest we implement this as the default setting. Presumably, anyone with a license file could get this version to run by running the trial license, plus Sentieon support can help to troubleshoot this if it's a problem. 

The main change is switching the license from `input` to a `params`. You now specify the IP address that the license is running on, which sets the environmental variable that specifies the Sentieon license.  