### PR TITLE
Fix mosdepth to 0.3.3 to resolve --d4 issue

### DIFF
--- a/workflow/envs/cov_filter.yml
+++ b/workflow/envs/cov_filter.yml
@@ -4,7 +4,7 @@ channels:
   - defaults
 dependencies:
   - bedtools==2.30.0
-  - mosdepth>=0.3.3
+  - mosdepth==0.3.3
   - d4tools>=0.3.4
   - pip
   - rust


### PR DESCRIPTION
mosdepth 0.3.4 was compiled without --d4. Likely the best solution is to fix 0.3.3 until the conda package is updated.