### PR TITLE
Update path, enable conda

### DIFF
--- a/docs/executing.md
+++ b/docs/executing.md
@@ -4,7 +4,7 @@ Please refer to our [setup instructions](./setup.md) to prepare the snpArcher en
 ## Test datasets
 To test that your environment is properly setup, you can run a quick test with the following command:
 ```
-snakemake -d ./test/ecoli --cores 1
+snakemake -d .test/ecoli --cores 1 --use-conda
 ```
 If this runs without errors, you are ready to go!
 ## Using the Dry-run option


### PR DESCRIPTION
Was unable to test the environment using the example in the docs.

Was able to resolve the error by:
- Updating path from `./test/ecoli ` to `.test/ecoli` [`./.test/ecoli` would also work].
- Including `--use-conda` in the command, otherwise it was unable to build the environments