### PR TITLE
update read group naming in common.smk

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -148,9 +148,10 @@ def collect_fastp_stats_input(wc):
 
 def get_read_group(wc):
     """Denote sample name and library_id in read group."""
-    return r"'@RG\tID:{lib}\tSM:{sample}\tPL:ILLUMINA'".format(
+    libname = samples.loc[samples['Run'] == wc.run]["LibraryName"].tolist()
+    return r"'@RG\tID:{lib}\tSM:{sample}\tLB:{lib}\tPL:ILLUMINA'".format(
         sample=wc.sample,
-        lib=wc.run
+        lib=libname
     )
 
 def get_input_sumstats(wildcards):


### PR DESCRIPTION
At the moment, the read group string is set by the "run" column. This means that the same library sequenced on multiple flow cells gets treated separately when duplicates are marked, even though duplicate marking happens after merging reads. The correct usage of the read group would set a library string and then the full RG string would be the same value for one library sequenced across multiple lanes. This should lead to GATK and Sentieon both marking duplicates according to the LibraryName column, while retaining the utility of the run column processing each run separately before bam merging.