### PR TITLE
Add scaffolds_to_exclude param in QC

### DIFF
--- a/.test/qc/config/config.yaml
+++ b/.test/qc/config/config.yaml
@@ -51,3 +51,6 @@ callable_merge: 100   #merge callable regions separated by this or fewer bp into
 ## QC options ##
 nClusters: 3
 GoogleAPIKey:
+
+## Filtering options ##
+scaffolds_to_exclude: "mtDNA,Y" #comma separated, no spaces list of scaffolds to exclude from final clean vcfs. Set to blank to disable.

--- a/workflow/modules/qc/Snakefile
+++ b/workflow/modules/qc/Snakefile
@@ -61,11 +61,18 @@ rule subsample_snps:
         sumstats = "results/{refGenome}/QC/{prefix}_bam_sumstats.txt"
     conda:
         "envs/subsample_snps.yml"
+    params:
+        chr_ex = config["scaffolds_to_exclude"]
     shell:
         """
         ##first remove filtered sites and retain only biallelic SNPs
         ##Also remove sites with MAF < 0.01 and those with > 75% missing data
-        bcftools view -S {input.samps} -t ^mtDNA -v snps -m2 -M2 -f .,PASS -e 'AF==1 | AF==0 | AF<0.01 | ALT="*" | F_MISSING > 0.75 | TYPE~"indel" | ref="N"' {input.vcf} -O z -o {output.filtered}
+        if [ -z "{params.chr_ex}" ]
+        then
+            bcftools view -S {input.samps} -v snps -m2 -M2 -f .,PASS -e 'AF==1 | AF==0 | AF<0.01 | ALT="*" | F_MISSING > 0.75 | TYPE~"indel" | ref="N"' {input.vcf} -O z -o {output.filtered}
+        else
+            bcftools view -S {input.samps} -t ^{params.chr_ex} -v snps -m2 -M2 -f .,PASS -e 'AF==1 | AF==0 | AF<0.01 | ALT="*" | F_MISSING > 0.75 | TYPE~"indel" | ref="N"' {input.vcf} -O z -o {output.filtered}
+        fi
         bcftools index {output.filtered}
 
         #figure out how many SNPs are left, then identify how big of SNP window size to get down to between 100 and 150k snps        


### PR DESCRIPTION
The QC rule subsample_snps currently removes mtDNA rather than the chromosomes specified by scaffolds_to_exclude. I've also updated the QC test to account for the scaffolds_to_exclude param.