### PR TITLE
Fix typo in mk module

### DIFF
--- a/workflow/modules/mk/Snakefile
+++ b/workflow/modules/mk/Snakefile
@@ -89,5 +89,5 @@ rule degenotate:
         else
             degenotate.py --overwrite -a {input.gff} -g {input.genome} -u {input.outgroups} -d {params.delim} -o "results/{wildcards.refGenome}/mk/{wildcards.prefix}_degen_raw" -v {input.vcf}
         fi
-        cp results/{wildcards.refGenome}/mk/{wildcards.prefix}_degen_raw/mk_table.tsv {output}
+        cp results/{wildcards.refGenome}/mk/{wildcards.prefix}_degen_raw/mk.tsv {output}
         """


### PR DESCRIPTION
Final output of degenotate is mk.tsv not mk_table.tsv