### PR TITLE
Add resources to rules

### DIFF
--- a/workflow/modules/postprocess/Snakefile
+++ b/workflow/modules/postprocess/Snakefile
@@ -37,6 +37,8 @@ rule basic_filter:
         filtered_idx = "results/{refGenome}/{prefix}_filtered.vcf.gz.csi"
     conda:
         "envs/filter.yml"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         bcftools view -S {input.include} -f .,PASS {input.vcf} -a -U -O u | bcftools +fill-tags -Ou |
@@ -56,9 +58,10 @@ rule update_bed:
         tmp_bed = temp("results/{refGenome}/postprocess/{prefix}_tmp.bed")
     conda:
         "envs/bed.yml"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 4000
     params:
         size_filter = config["contig_size"],
-        
     shell:
         """
         awk 'BEGIN{{OFS="\\t"}}{{if ($2<{params.size_filter}) {{print $1,0,$2}}}}' {input.fai} > {output.tmp_bed}
@@ -79,6 +82,8 @@ rule strict_filter:
         miss = config["missingness"],
         maf = config["maf"],
         chr_ex = config["scaffolds_to_exclude"]
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 4000    
     shell:
         """
         if [ -z "{params.chr_ex}" ]
@@ -108,6 +113,8 @@ rule subset_indels:
         "envs/filter.yml"
     log:
         "logs/{refGenome}/postprocess/{prefix}_subset_indels.txt"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         bcftools view -v indels -O z -o {output.vcf} {input.vcf}
@@ -128,6 +135,8 @@ rule subset_snps:
         "envs/filter.yml"    
     log:
         "logs/{refGenome}/postprocess/{prefix}_subset_snps.txt"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         bcftools view -v snps -e 'TYPE ~ "indel"' -O z -o {output.vcf} {input.vcf}

--- a/workflow/modules/qc/Snakefile
+++ b/workflow/modules/qc/Snakefile
@@ -20,6 +20,8 @@ rule check_fai:
         fai = "results/{refGenome}/data/genome/{refGenome}.fna.fai",
     output:
         faiResult = "results/{refGenome}/QC/{prefix}_fai_tmp.txt"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 1000
     run:
         check_contig_names(input.fai, output.faiResult)
 
@@ -37,6 +39,8 @@ rule vcftools_individuals:
     params:
         prefix = lambda wc, input: os.path.join(input.vcf.rsplit("/", 1)[0], "QC", wc.prefix),
         min_depth = config["min_depth"]
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         vcftools --gzvcf {input.vcf} --FILTER-summary --out {params.prefix}
@@ -63,6 +67,8 @@ rule subsample_snps:
         "envs/subsample_snps.yml"
     params:
         chr_ex = config["scaffolds_to_exclude"]
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         ##first remove filtered sites and retain only biallelic SNPs

--- a/workflow/rules/cov_filter.smk
+++ b/workflow/rules/cov_filter.smk
@@ -64,6 +64,8 @@ rule create_cov_bed:
         cov_threshold_rel = config["cov_threshold_rel"]
     conda:
         "../envs/cov_filter.yml"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * resources['callable_bed']['mem']
     script:
         "../scripts/create_coverage_bed.py"
 


### PR DESCRIPTION
Adds resources to define memory for a few rules that are otherwise missing resources statements to hopefully avoid the current issue where the inferred defaults are massively to big and cause jobs to fail, e.g. #153, #148.

Might be a better way to do this in the future as we move to a different way to support slurm, but for now hopefully this will fix problems.