### PR TITLE
Feat  optional dedup

### DIFF
--- a/.test/ci/config/config.yaml
+++ b/.test/ci/config/config.yaml
@@ -14,6 +14,7 @@ bigtmp: "" #Set to a path with lots of free space to use for commands that requi
 cov_filter: True #set to True if you want to include coverage thresholds in the callable sites bed file (default uses mappability only)
 generate_trackhub: True #Set to true if you want to generate a Genome Browser Trackhub. Dependent on postprocessing module.
 trackhub_email: "hi@website.com"
+mark_duplicates: True
 ##############################
 # Variables you *might* need to change
 ##############################

--- a/.test/ecoli/config/config.yaml
+++ b/.test/ecoli/config/config.yaml
@@ -13,13 +13,13 @@ bigtmp: "" #Set to a path with lots of free space to use for commands that requi
 cov_filter: True #set to True if you want to include coverage thresholds in the callable sites bed file (default uses mappability only)
 generate_trackhub: True #Set to true if you want to generate a Genome Browser Trackhub. Dependent on postprocessing module.
 trackhub_email: "hi@website.com"
-
+mark_duplicates: True
 ##############################
 # Variables you *might* need to change
 ##############################
 
-refGenome: 
-refPath:
+#refGenome: 
+#refPath:
 
 # Interval approach options, only applicable if intervals is True
 minNmer: 500 # the minimum Nmer used to split up the genome; e.g. a value of 200 means only Nmers 200 or greater are used to define the boundaries of intervals. The minimum is 50.

--- a/workflow/rules/bam2vcf_gatk.smk
+++ b/workflow/rules/bam2vcf_gatk.smk
@@ -5,11 +5,10 @@ rule bam2gvcf:
     TODO
     """
     input:
+        unpack(get_bams),
         ref = "results/{refGenome}/data/genome/{refGenome}.fna",
         indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"]),
         dictf = "results/{refGenome}/data/genome/{refGenome}.dict",
-        bam = "results/{refGenome}/bams/{sample}_final.bam",
-        bai = "results/{refGenome}/bams/{sample}_final.bam.bai",
         
     output:
         gvcf = "results/{refGenome}/gvcfs/{sample}.g.vcf.gz",

--- a/workflow/rules/bam2vcf_gatk_intervals.smk
+++ b/workflow/rules/bam2vcf_gatk_intervals.smk
@@ -5,12 +5,12 @@ rule bam2gvcf:
     TODO
     """
     input:
+        unpack(get_bams),
         ref = "results/{refGenome}/data/genome/{refGenome}.fna",
         indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"]),
         dictf = "results/{refGenome}/data/genome/{refGenome}.dict",
-        bam = "results/{refGenome}/bams/{sample}_final.bam",
-        bai = "results/{refGenome}/bams/{sample}_final.bam.bai",
-        l = "results/{refGenome}/intervals/gvcf_intervals/{l}-scattered.interval_list"
+        l = "results/{refGenome}/intervals/gvcf_intervals/{l}-scattered.interval_list",
+        
     output:
         gvcf = "results/{refGenome}/interval_gvcfs/{sample}/{l}.raw.g.vcf.gz",
         gvcf_idx = "results/{refGenome}/interval_gvcfs/{sample}/{l}.raw.g.vcf.gz.tbi"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -130,6 +130,15 @@ def get_ref(wildcards):
                     f"Will try to download '{wildcards.refGenome}' from NCBI. If this is a genome accession, you can ignore this warning.")
     return []
 
+def get_bams(wc):
+    out = {"bam": None, "bai": None}
+    if config["mark_duplicates"]:
+        out["bam"] = "results/{refGenome}/bams/{sample}_final.bam"
+        out["bai"] = "results/{refGenome}/bams/{sample}_final.bam.bai"
+        return out
+    else:
+        return dedup_input(wc)
+
 def sentieon_combine_gvcf_cmd_line(wc):
     gvcfs = sentieon_combine_gvcf_input(wc)["gvcfs"]
     return " ".join(["-v " + gvcf for gvcf in gvcfs])

--- a/workflow/rules/cov_filter.smk
+++ b/workflow/rules/cov_filter.smk
@@ -1,7 +1,6 @@
 rule compute_d4:
     input:
-        bam = "results/{refGenome}/bams/{sample}_final.bam",
-        bai = "results/{refGenome}/bams/{sample}_final.bam.bai",
+        unpack(get_bams)
     output:
         "results/{refGenome}/callable_sites/{sample}.mosdepth.global.dist.txt",
         temp("results/{refGenome}/callable_sites/{sample}.per-base.d4"),

--- a/workflow/rules/sentieon.smk
+++ b/workflow/rules/sentieon.smk
@@ -63,11 +63,10 @@ rule sentieon_dedup:
 
 rule sentieon_haplotyper:
     input:
+        unpack(get_bams),
         ref = "results/{refGenome}/data/genome/{refGenome}.fna",
         indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"]),
         dictf = "results/{refGenome}/data/genome/{refGenome}.dict",
-        bam = "results/{refGenome}/bams/{sample}_final.bam",
-        bai = "results/{refGenome}/bams/{sample}_final.bam.bai"
     params:
         lic = config['sentieon_lic'],
         ploidy = config['ploidy']

--- a/workflow/rules/sumstats.smk
+++ b/workflow/rules/sumstats.smk
@@ -1,7 +1,6 @@
 rule bam_sumstats:
     input:
-        bam = "results/{refGenome}/bams/{sample}_final.bam",
-        bai = "results/{refGenome}/bams/{sample}_final.bam.bai",
+        unpack(get_bams),
         ref = "results/{refGenome}/data/genome/{refGenome}.fna",
     output:
         cov = "results/{refGenome}/summary_stats/{sample}_coverage.txt",
@@ -16,8 +15,7 @@ rule bam_sumstats:
 
 rule sentieon_bam_stats:
     input:
-        bam = "results/{refGenome}/bams/{sample}_final.bam",
-        bai = "results/{refGenome}/bams/{sample}_final.bam.bai",
+        unpack(get_bams),
         indexes = expand("results/{{refGenome}}/data/genome/{{refGenome}}.fna.{ext}", ext=["sa", "pac", "bwt", "ann", "amb", "fai"]),
         ref = "results/{refGenome}/data/genome/{refGenome}.fna"
     params:


### PR DESCRIPTION
adds optional dedup. default is to mark duplicates. if skipping marking duplicates, need to add `--notemp` when executing snakemake to preserve bams. 