### PR TITLE
use json summary from fastp to make sure all stdout/stderr goes to log

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -4,6 +4,7 @@ import tempfile
 import random
 import string
 import statistics
+import json
 from pathlib import Path
 from collections import defaultdict
 
@@ -397,21 +398,12 @@ def collectFastpOutput(fastpFiles):
     for fn in fastpFiles:
         sample = os.path.basename(fn)
         sample = sample.replace("_fastp.out", "")
-        unfiltered = 0
-        pass_filter = 0
-        f = open(fn, "r")
-        for line in f:
-            if "before filtering" in line:
-                line = next(f)
-                line = line.split()
-                unfiltered += int(line[2])
-
-            if "Filtering result" in line:
-                line = next(f)
-                line = line.split()
-                pass_filter += int(line[3])
-
-        f.close()
+        
+        
+        with open(fn, "r") as f:
+            data = json.load(f)
+        unfiltered = data["summary"]["before_filtering"]["total_reads"]
+        pass_filter = data["summary"]["after_filtering"]["total_reads"]
         FractionReadsPassFilter[sample] = float(pass_filter / unfiltered)
         NumReadsPassFilter[sample] = pass_filter
 

--- a/workflow/rules/fastq.smk
+++ b/workflow/rules/fastq.smk
@@ -46,5 +46,5 @@ rule fastp:
         "--out1 {output.r1} --out2 {output.r2} "
         "--thread {threads} "
         "--detect_adapter_for_pe "
-        "-j /dev/null -h /dev/null "
-        "2> {output.summ} > {log}"
+        "-j {output.summ} -h /dev/null "
+        " &>{log}"


### PR DESCRIPTION
Should help with #183. I suspect whatever error occured in fastp in that issue was written to the summary.out, which then got deleted by snakemake