### PR TITLE
add config option to sort reads with bbmap before read trimming

### DIFF
--- a/.test/ci/config/config.yaml
+++ b/.test/ci/config/config.yaml
@@ -15,6 +15,7 @@ cov_filter: True #set to True if you want to include coverage thresholds in the 
 generate_trackhub: True #Set to true if you want to generate a Genome Browser Trackhub. Dependent on postprocessing module.
 trackhub_email: "hi@website.com"
 mark_duplicates: True
+sort_reads: False
 ##############################
 # Variables you *might* need to change
 ##############################

--- a/.test/ecoli/config/config.yaml
+++ b/.test/ecoli/config/config.yaml
@@ -14,6 +14,7 @@ cov_filter: True #set to True if you want to include coverage thresholds in the 
 generate_trackhub: True #Set to true if you want to generate a Genome Browser Trackhub. Dependent on postprocessing module.
 trackhub_email: "hi@website.com"
 mark_duplicates: True
+sort_reads: False
 ##############################
 # Variables you *might* need to change
 ##############################

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -14,6 +14,7 @@ cov_filter: True #set to True if you want to include coverage thresholds in the 
 generate_trackhub: True #Set to true if you want to generate a Genome Browser Trackhub. Dependent on postprocessing module.
 trackhub_email: ""
 mark_duplicates: True
+sort_reads: False
 ##############################
 # Variables you *might* need to change
 ##############################

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -114,7 +114,7 @@ The following options in `config/config.yaml` must be set before running snpArch
 | `refGenome` | Reference genome name or accession | `str` | `True` if not provided in sample sheet |  `None` |
 | `refPath` | Path to reference genome if not using NCBI genome accession | `str` | `False` | `None` |
 | `mark_duplicates` | Mark optical duplicates before variant calling. | `str` | `True` | `True` |
-
+| `sort_reads` | Sort reads by read name before running adapter trimming. | `str` | `True` | `False` |
 
 ### Other options
 The following options can be adjusted based on your needs and your dataset.

--- a/workflow/envs/fastq2bam.yml
+++ b/workflow/envs/fastq2bam.yml
@@ -12,5 +12,6 @@ dependencies:
   - pigz==2.6
   - curl>7.73.0
   - pip==22.0.4
+  - bbmap==38.96
   - pip:
       - ffq

--- a/workflow/rules/fastq.smk
+++ b/workflow/rules/fastq.smk
@@ -41,10 +41,32 @@ rule fastp:
         "logs/{refGenome}/fastp/{sample}/{run}.txt"
     benchmark:
         "benchmarks/{refGenome}/fastp/{sample}_{run}.txt"
+    params:
+        sort_reads = config['sort_reads']
     shell:
-        "fastp --in1 {input.r1} --in2 {input.r2} "
-        "--out1 {output.r1} --out2 {output.r2} "
-        "--thread {threads} "
-        "--detect_adapter_for_pe "
-        "-j {output.summ} -h /dev/null "
-        " &>{log}"
+        """
+        if [ {params.sort_reads} = "True" ]; then
+        
+            sortbyname.sh in={input.r1} out={wildcards.run}_sorted_R1.fastq.gz
+            sortbyname.sh in={input.r2} out={wildcards.run}_sorted_R2.fastq.gz
+
+            echo {params.sortreads}
+
+            fastp --in1 {wildcards.run}_sorted_R1.fastq.gz --in2 {wildcards.run}_sorted_R2.fastq.gz \
+            --out1 {output.r1} --out2 {output.r2} \
+            --thread {threads} \
+            --detect_adapter_for_pe \
+            -j {output.summ} -h /dev/null \
+            &>{log}
+
+            rm {wildcards.run}_sorted_R1.fastq.gz
+            rm {wildcards.run}_sorted_R2.fastq.gz
+        else
+            fastp --in1 {input.r1} --in2 {input.r2} \
+            --out1 {output.r1} --out2 {output.r2} \
+            --thread {threads} \
+            --detect_adapter_for_pe \
+            -j {output.summ} -h /dev/null \
+            &>{log}
+        fi
+        """

--- a/workflow/rules/fastq.smk
+++ b/workflow/rules/fastq.smk
@@ -50,8 +50,6 @@ rule fastp:
             sortbyname.sh in={input.r1} out={wildcards.run}_sorted_R1.fastq.gz
             sortbyname.sh in={input.r2} out={wildcards.run}_sorted_R2.fastq.gz
 
-            echo {params.sortreads}
-
             fastp --in1 {wildcards.run}_sorted_R1.fastq.gz --in2 {wildcards.run}_sorted_R2.fastq.gz \
             --out1 {output.r1} --out2 {output.r2} \
             --thread {threads} \


### PR DESCRIPTION
Every so often (way more often than seems reasonable) reads are delivered to me unsorted by read name. This happens pretty often with reads downloaded from NCBI as well. I added a config option to sort reads by name using bbmaps read sorter, which seems to be efficient in my experience. 

It's fast enough that I almost wonder if it should be the default to sort reads, but I guess for most use cases, it's best to have it be user-defined. 

It's a little inelegant how I set it up, just a bash ifelse statement, but it works...