### PR TITLE
Postprocessing update

### DIFF
--- a/workflow/modules/postprocess/Snakefile
+++ b/workflow/modules/postprocess/Snakefile
@@ -95,14 +95,16 @@ rule strict_filter:
         mem_mb = lambda wildcards, attempt: attempt * 4000    
     shell:
         """
+        upper_bound=$(echo "scale=2; 1 - {params.maf}" | bc)
+
         if [ -z "{params.chr_ex}" ]
         then
             bcftools view -R {input.bed} -m2 -M2 \
-            -e 'F_MISSING > {params.miss} | AF<{params.maf}' \
+            -e 'F_MISSING > {params.miss} | AF<{params.maf} | AF>$upper_bound' \
             {input.vcf} -O u -o {output.vcf}
         else
             bcftools view -t ^{params.chr_ex} -R {input.bed} -m2 -M2 \
-            -e 'F_MISSING > {params.miss} | AF<{params.maf}' \
+            -e 'F_MISSING > {params.miss} | AF<{params.maf} | AF>$upper_bound' \
             {input.vcf} -O u -o {output.vcf} 
         fi
         bcftools index {output.vcf}
@@ -138,8 +140,8 @@ rule subset_snps:
         vcf = "results/{refGenome}/postprocess/{prefix}_filtered.TEMP.vcf.gz",
         idx = "results/{refGenome}/postprocess/{prefix}_filtered.TEMP.vcf.gz.csi"
     output: 
-        vcf = "results/{refGenome}/{prefix}_clean_snps.vcf.gz",
-        idx = "results/{refGenome}/{prefix}_clean_snps.vcf.gz.tbi"
+        vcf = temp("results/{refGenome}/{prefix}_clean_snps_1.vcf.gz"),
+        idx = temp("results/{refGenome}/{prefix}_clean_snps_1.vcf.gz.tbi")
     conda:
         "envs/filter.yml"    
     log:
@@ -149,5 +151,29 @@ rule subset_snps:
     shell:
         """
         bcftools view -v snps -e 'TYPE ~ "indel"' -O z -o {output.vcf} {input.vcf}
+        bcftools index -t {output.vcf}
+        """
+
+rule drop_indel_SNPs:
+    """
+    identify and remove SNPs that overlapped with indels and are coded as genotype length > 1
+    """
+    input: 
+        vcf = "results/{refGenome}/{prefix}_clean_snps.vcf.gz",
+        idx = "results/{refGenome}/{prefix}_clean_snps.vcf.gz.tbi"
+    output:
+        indel_snps = temp("results/{refGenome}/{prefix}_indel_snp_positions.txt"),
+        vcf = "results/{refGenome}/{prefix}_clean_snps.vcf.gz",
+        idx = "results/{refGenome}/{prefix}_clean_snps.vcf.gz.tbi"
+    conda:
+        "envs/filter.yml"    
+    log:
+        "logs/{refGenome}/postprocess/{prefix}_drop_indel_snps.txt"
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 4000
+    shell:
+        """
+        bcftools query -f '%CHROM\t%POS\t%REF\n' {input.vcf} | awk 'length($3) == 1 {{print $1"\t"$2}}' > {output.indel_snps}
+        bcftools view -R {output.indel_snps} {input.vcf} -Oz -o {output.vcf}
         bcftools index -t {output.vcf}
         """

--- a/workflow/modules/postprocess/Snakefile
+++ b/workflow/modules/postprocess/Snakefile
@@ -90,21 +90,20 @@ rule strict_filter:
     params:
         miss = config["missingness"],
         maf = config["maf"],
-        chr_ex = config["scaffolds_to_exclude"]
+        upper_bound = lambda wildcards: 1 - float(config["maf"]),
+        chr_ex = config["scaffolds_to_exclude"],
     resources:
         mem_mb = lambda wildcards, attempt: attempt * 4000    
     shell:
         """
-        upper_bound=$(echo "scale=2; 1 - {params.maf}" | bc)
-
         if [ -z "{params.chr_ex}" ]
         then
             bcftools view -R {input.bed} -m2 -M2 \
-            -e 'F_MISSING > {params.miss} | AF<{params.maf} | AF>$upper_bound' \
+            -e 'F_MISSING > {params.miss} | AF<{params.maf} | AF>{params.upper_bound}' \
             {input.vcf} -O u -o {output.vcf}
         else
             bcftools view -t ^{params.chr_ex} -R {input.bed} -m2 -M2 \
-            -e 'F_MISSING > {params.miss} | AF<{params.maf} | AF>$upper_bound' \
+            -e 'F_MISSING > {params.miss} | AF<{params.maf} | AF>{params.upper_bound}' \
             {input.vcf} -O u -o {output.vcf} 
         fi
         bcftools index {output.vcf}
@@ -140,8 +139,8 @@ rule subset_snps:
         vcf = "results/{refGenome}/postprocess/{prefix}_filtered.TEMP.vcf.gz",
         idx = "results/{refGenome}/postprocess/{prefix}_filtered.TEMP.vcf.gz.csi"
     output: 
-        vcf = temp("results/{refGenome}/{prefix}_clean_snps_1.vcf.gz"),
-        idx = temp("results/{refGenome}/{prefix}_clean_snps_1.vcf.gz.tbi")
+        vcf = temp("results/{refGenome}/postprocess/{prefix}_clean_snps_1.vcf.gz"),
+        idx = temp("results/{refGenome}/postprocess/{prefix}_clean_snps_1.vcf.gz.tbi")
     conda:
         "envs/filter.yml"    
     log:
@@ -159,10 +158,10 @@ rule drop_indel_SNPs:
     identify and remove SNPs that overlapped with indels and are coded as genotype length > 1
     """
     input: 
-        vcf = "results/{refGenome}/{prefix}_clean_snps.vcf.gz",
-        idx = "results/{refGenome}/{prefix}_clean_snps.vcf.gz.tbi"
+        vcf = "results/{refGenome}/postprocess/{prefix}_clean_snps_1.vcf.gz",
+        idx = "results/{refGenome}/postprocess/{prefix}_clean_snps_1.vcf.gz.tbi"
     output:
-        indel_snps = temp("results/{refGenome}/{prefix}_indel_snp_positions.txt"),
+        indel_snps = temp("results/{refGenome}/postprocess/{prefix}_indel_snp_positions.txt"),
         vcf = "results/{refGenome}/{prefix}_clean_snps.vcf.gz",
         idx = "results/{refGenome}/{prefix}_clean_snps.vcf.gz.tbi"
     conda:


### PR DESCRIPTION
I'm addressing two issues here. The first is that our maf filter isn't correctly set in the strict filter (we don't remove SNPs at 1-params.maf) and I think this is a necessary change. The second is identifying SNP positions that are of length > 1 and removing them. 

Here is an example of a site that is retained by the filters currently:

```
JALCYL010000001.1       775994  .       AC      CC      11928.3 .
```

The original raw vcf call is as follows:

```
JALCYL010000001.1       775994  .       AC      CC,A    11928.28        .
```

So in postprocessing, we remove the deletion, but the length of the genotype doesn't change. We could probably recode these as SNPs, but given that SNPs overlapping indels are more likely to be errors, it seems sensible to just remove them altogether. The formatting as is affects some downstream analyses that extract nucleotides for genotype positions. 

I am interested in input on the second one, especially if anyone has a more clever way of doing it. This is reasonably fast, anyway. 



