### PR TITLE
remove resources from rules

### DIFF
--- a/workflow/modules/postprocess/Snakefile
+++ b/workflow/modules/postprocess/Snakefile
@@ -46,8 +46,6 @@ rule basic_filter:
         filtered_idx = "results/{refGenome}/{prefix}_filtered.vcf.gz.csi"
     conda:
         "envs/filter.yml"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         bcftools view -S {input.include} -f .,PASS {input.vcf} -a -U -O u | bcftools +fill-tags -Ou |
@@ -67,8 +65,6 @@ rule update_bed:
         tmp_bed = temp("results/{refGenome}/postprocess/{prefix}_tmp.bed")
     conda:
         "envs/bed.yml"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 4000
     params:
         size_filter = config["contig_size"],
     shell:
@@ -91,9 +87,7 @@ rule strict_filter:
         miss = config["missingness"],
         maf = config["maf"],
         upper_bound = lambda wildcards: 1 - float(config["maf"]),
-        chr_ex = config["scaffolds_to_exclude"],
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 4000    
+        chr_ex = config["scaffolds_to_exclude"],   
     shell:
         """
         if [ -z "{params.chr_ex}" ]
@@ -123,8 +117,6 @@ rule subset_indels:
         "envs/filter.yml"
     log:
         "logs/{refGenome}/postprocess/{prefix}_subset_indels.txt"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         bcftools view -v indels -O z -o {output.vcf} {input.vcf}
@@ -145,8 +137,6 @@ rule subset_snps:
         "envs/filter.yml"    
     log:
         "logs/{refGenome}/postprocess/{prefix}_subset_snps.txt"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         bcftools view -v snps -e 'TYPE ~ "indel"' -O z -o {output.vcf} {input.vcf}
@@ -168,8 +158,6 @@ rule drop_indel_SNPs:
         "envs/filter.yml"    
     log:
         "logs/{refGenome}/postprocess/{prefix}_drop_indel_snps.txt"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         bcftools query -f '%CHROM\t%POS\t%REF\n' {input.vcf} | awk 'length($3) == 1 {{print $1"\t"$2}}' > {output.indel_snps}

--- a/workflow/modules/qc/Snakefile
+++ b/workflow/modules/qc/Snakefile
@@ -18,8 +18,6 @@ rule check_fai:
         fai = "results/{refGenome}/data/genome/{refGenome}.fna.fai",
     output:
         faiResult = "results/{refGenome}/QC/{prefix}_fai_tmp.txt"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 1000
     run:
         check_contig_names(input.fai, output.faiResult)
 
@@ -39,8 +37,6 @@ rule vcftools_individuals:
         min_depth = config["min_depth"]
     log:
         "logs/{refGenome}/QC/vcftools_individuals/{prefix}.txt"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         vcftools --gzvcf {input.vcf} --FILTER-summary --out {params.prefix} &> {log}
@@ -69,8 +65,6 @@ rule subsample_snps:
         chr_ex = config["scaffolds_to_exclude"]
     log:
         "logs/{refGenome}/QC/subsample_snps/{prefix}.txt"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 4000
     shell:
         """
         ##first remove filtered sites and retain only biallelic SNPs
@@ -124,8 +118,6 @@ rule plink:
         "envs/plink.yml"
     log:
         "logs/{refGenome}/QC/plink/{prefix}.txt"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 2000
     shell:
         #plink 2 for king relatedness matrix (robust to structure) and plink 1.9 for distance matrix
         """
@@ -163,8 +155,6 @@ rule admixture:
         outdir = lambda wc, input: input.bed.rsplit("/", 1)[0]
     log:
         "logs/{refGenome}/QC/admixture/{prefix}.txt"
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 4000
     conda:
         "envs/admixture.yml"
     shell:
@@ -215,8 +205,6 @@ rule qc_plots:
         prefix = lambda wc, input: input.het[:-4],
         nClusters = config['nClusters'],
         GMKey = config['GoogleAPIKey']
-    resources:
-        mem_mb = lambda wildcards, attempt: attempt * 2000
     output: 
         qcpdf = "results/{refGenome}/QC/{prefix}_qc.html"
     conda:


### PR DESCRIPTION
These resource requests per rule override the default we set in the profile/config.yaml. To me this seems to only cause confusing problems. They were removed elsewhere in the workflow, but not in the modules. Removing them unless @tsackton see's a reason to keep them around? 