### PR TITLE
fix issue with trackhub

### DIFF
--- a/workflow/modules/trackhub/Snakefile
+++ b/workflow/modules/trackhub/Snakefile
@@ -178,9 +178,14 @@ rule non_callable_sites:
         bb = "results/{refGenome}/trackhub/non_callable_sites.bb"
     conda:
         "envs/trackhub.yml"
+    shadow:
+        "minimal"
     shell:
         """
-        sort -k1,1 {input.chrom_sizes} > sorted.chrom.sizes
-        bedtools complement -i {input.callable_sites} -g sorted.chrom.sizes > {output.bed}
-        bedToBigBed {output.bed} {input.chrom_sizes} {output.bb}
+        sort -k1,1V {input.chrom_sizes} > sorted.chrom.sizes
+        sort -k1,1V -k2,2n {input.callable_sites} >  sorted_callable_sites.bed
+        bedtools complement -i sorted_callable_sites.bed -g sorted.chrom.sizes > {output.bed}
+
+        bedSort {output.bed} bedsort_non_callable_sites.bed
+        bedToBigBed bedsort_non_callable_sites.bed sorted.chrom.sizes {output.bb}
         """

--- a/workflow/modules/trackhub/envs/trackhub.yml
+++ b/workflow/modules/trackhub/envs/trackhub.yml
@@ -8,3 +8,4 @@ dependencies:
   - vcftools==0.1.16
   - ucsc-bedgraphtobigwig==377
   - ucsc-bedtobigbed==377
+  - ucsc-bedsort==466


### PR DESCRIPTION
This was a doozy to track down, but I have been having issues with bed sorting for plant species with chloroplasts when building track hubs. Similar to issues [here](https://groups.google.com/a/soe.ucsc.edu/g/genome/c/utzMtbvIBVQ). 

e.g. here's the end of a sorted.chrom.sizes that cause issues because it is sorted differently depending on if you do case-sorting or not:
```
SCAF_100        30392
SCAF_101        20804
SCAF_102        18621
SCAF_103        12751
chloroplast     155214
```

The solution is to case sort before running bedtools complement. Then sort the non callable sites file using bedSort (for whatever reason relating to locale, sort doesn't work for this). This seems most robust to variation on different linux configurations of locale. 