### PR TITLE
make sort reads its own rule

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -250,6 +250,12 @@ def get_reads(wc):
     else:
         return {"r1": r1, "r2": r2}
 
+def get_reads_fastp(wc):
+    if config.get("sort_reads", False):
+        return {"r1":"results/{refGenome}/sorted_reads/{sample}/{run}_1.fastq.gz", "r2":"results/{refGenome}/sorted_reads/{sample}/{run}_2.fastq.gz"}
+    else:
+        return get_reads(wc)
+
 def get_remote_reads(wildcards):
     """Use this for reads on a different remote bucket than the default. For backwards compatibility."""
     # print(wildcards)


### PR DESCRIPTION
This should fix #225. Snakemake doesn't know about the sorted reads intermediate files leading to weird things happening. 

This PR just breaks sort reads into its own rule and uses the config option to request the right files. 