### PR TITLE
fix: use bedtk to merge clam callable bed b/c its more mem efficient

### DIFF
--- a/workflow/envs/cov_filter.yml
+++ b/workflow/envs/cov_filter.yml
@@ -7,4 +7,5 @@ dependencies:
   - mosdepth==0.3.10
   - d4tools>=0.3.10
   - clam>=0.1.2
+  - bedtk==0.0.r25.dirty
   

--- a/workflow/rules/cov_filter.smk
+++ b/workflow/rules/cov_filter.smk
@@ -76,7 +76,6 @@ rule clam_loci:
 
 rule callable_bed:
     input:
-        
         cov = "results/{refGenome}/callable_sites/{prefix}/callable_sites.bed",
         map = "results/{refGenome}/callable_sites/{prefix}_callable_sites_map.bed"
     output:

--- a/workflow/rules/cov_filter.smk
+++ b/workflow/rules/cov_filter.smk
@@ -57,7 +57,8 @@ rule clam_loci:
         thresholds = "results/{refGenome}/callable_sites/{prefix}_callable_sites_thresholds.tsv"
     output:
         cov = "results/{refGenome}/callable_sites/{prefix}/callable_sites.d4",
-        bed = "results/{refGenome}/callable_sites/{prefix}/callable_sites.bed"
+        tmpbed = temp("results/{refGenome}/callable_sites/{prefix}/callable_sites.bed"),
+        mergedbed = "results/{refGenome}/callable_sites/{prefix}/merged_callable_sites.bed" # temp fix until clam produces better bed files cm
     params:
         outdir = subpath(output.cov, parent=True)
     conda:
@@ -67,9 +68,14 @@ rule clam_loci:
     benchmark:
         "benchmarks/{refGenome}/covbed/{prefix}_benchmark.txt"
     shell:
-        "clam loci -t {threads} --bed --thresholds-file {input.thresholds} -o {params.outdir} {input.d4} 2> {log}"
+        """
+        clam loci -t {threads} --bed --thresholds-file {input.thresholds} -o {params.outdir} {input.d4} 2> {log}
+        bedtk merge {output.tmpbed} > {output.mergedbed} 2>> {log}
+        """
+
 rule callable_bed:
     input:
+        mergedbed = "results/{refGenome}/callable_sites/{prefix}/merged_callable_sites.bed",
         cov = "results/{refGenome}/callable_sites/{prefix}/callable_sites.bed",
         map = "results/{refGenome}/callable_sites/{prefix}_callable_sites_map.bed"
     output:
@@ -83,6 +89,6 @@ rule callable_bed:
         merge = config['cov_merge']
     shell:
         """
-        bedtools sort -i {input.cov} | bedtools merge -d {params.merge} -i - > {output.tmp_cov}
+        bedtools merge -d {params.merge} -i {input.mergedbed} > {output.tmp_cov}
         bedtools intersect -a {output.tmp_cov} -b {input.map} | bedtools sort -i - | bedtools merge -i - > {output.callable_sites}
         """

--- a/workflow/rules/cov_filter.smk
+++ b/workflow/rules/cov_filter.smk
@@ -71,7 +71,7 @@ rule clam_loci:
         """
         clam loci -t {threads} --bed --thresholds-file {input.thresholds} -o {params.outdir} {input.d4} 2> {log}
         bedtk merge {output.bed} > {output.tmp_bed} 2>> {log}
-        mv {output.tmp_bed} {output.bed} 2>> {log}
+        cp {output.tmp_bed} {output.bed} 2>> {log}
         """
 
 rule callable_bed:

--- a/workflow/rules/cov_filter.smk
+++ b/workflow/rules/cov_filter.smk
@@ -71,7 +71,7 @@ rule clam_loci:
         """
         clam loci -t {threads} --bed --thresholds-file {input.thresholds} -o {params.outdir} {input.d4} 2> {log}
         bedtk merge {output.bed} > {output.tmp_bed} 2>> {log}
-        mv {output.tmp_bed} {output.bed}
+        mv {output.tmp_bed} {output.bed} 2>> {log}
         """
 
 rule callable_bed:


### PR DESCRIPTION
clam currently produces a callable bed file that is perbase, which makes bedtools use lots of ram. while i work on a fix for this in clam, this should alleviate this issue