### PR TITLE
Fall back to fastq-dump for heavily-aligned SRA runs

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -5,6 +5,25 @@ samples: "config/samples.csv"
 # Optional: per-sample metadata for modules (exclude, outgroup, lat, long, etc.)
 # sample_metadata: "config/sample_metadata.csv"
 
+reads:
+  mark_duplicates: true
+  sra:
+    # fasterq-dump is the default extractor. For reference-aligned (cSRA)
+    # submissions it builds a spot-id lookup over every alignment, which does
+    # not scale: a run with 1.1e9 alignments against an 8.9 Gbp reference
+    # projects to ~577 h, versus ~3.3 h for fastq-dump. The two produce
+    # byte-identical FASTQ, so snpArcher falls back to fastq-dump when needed.
+    #
+    # Budget for fasterq-dump before falling back. A backstop, not a target:
+    # a healthy 400M-spot aligned run finishes in well under an hour.
+    fasterq_budget_minutes: 360
+    # Skip fasterq-dump outright when BOTH thresholds are met. Both must hold,
+    # because alignment count and reference size are confounded in the only
+    # dataset where this has been measured. Set alignments to 0 to disable the
+    # shortcut and let the budget decide every time.
+    direct_fastq_dump_min_alignments: 300000000
+    direct_fastq_dump_min_reference_bp: 3000000000
+
 reference:
   name: "my_organism"
   source: "/data/reference/genome.fna.gz"  # Can be a refseq/genbank accession, url, or path

--- a/workflow-profiles/default/config.yaml
+++ b/workflow-profiles/default/config.yaml
@@ -47,6 +47,15 @@ set-threads:
 # mem_mb controls the scheduler request. mem_mb_reduced controls tool memory
 # budgets below the scheduler limit and should be an integer number of MB.
 set-resources:
+  # Fastq Processing
+  # runtime must cover reads.sra.fasterq_budget_minutes plus the fastq-dump
+  # fallback that follows it; the default 360 min budget plus a large aligned
+  # run's extraction fits inside 2880. Observed peak RSS for both extractors is
+  # ~14 GB, and neither uses more when given more.
+  download_sra:
+    mem_mb: attempt * 24000
+    runtime: 2880
+
   # Alignment
   bwa_mem:
     mem_mb: attempt * 16000

--- a/workflow/envs/sra.yaml
+++ b/workflow/envs/sra.yaml
@@ -3,6 +3,7 @@ channels:
   - bioconda
 dependencies:
   - sra-tools=3.2.1
+  - coreutils  # `timeout`, used to budget fasterq-dump before falling back
   - pigz>=2.6
   - curl>=7.73
   - ffq >=0.3.1

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -56,6 +56,11 @@ DEFAULTS = {
     "sample_metadata": "",
     "reads": {
         "mark_duplicates": True,
+        "sra": {
+            "fasterq_budget_minutes": 360,
+            "direct_fastq_dump_min_alignments": 300_000_000,
+            "direct_fastq_dump_min_reference_bp": 3_000_000_000,
+        },
     },
     "variant_calling": {
         "expected_coverage": "low",

--- a/workflow/rules/fastq.smk
+++ b/workflow/rules/fastq.smk
@@ -1,3 +1,39 @@
+# --- SRA extraction tuning ---------------------------------------------------
+#
+# fasterq-dump is the right default: it is multi-threaded and beats fastq-dump
+# by roughly 2x on ordinary runs. But for reference-aligned submissions (cSRA,
+# loaded from BAM by bam-load) it re-pairs reads by building a spot-id lookup
+# over the PRIMARY_ALIGNMENT table, sorted externally in its temp dir, and that
+# phase does not scale. Measured against Pseudophryne corroboree data:
+#
+#   accession     aligned reads   reference    fasterq-dump    fastq-dump
+#   SRR000001     0 (unaligned)   -                     3 s           6 s
+#   SRR28349113   54.2M           0.69 Gbp          47 min        88 min
+#   SRR28349114   1,108.7M        8.88 Gbp    ~577 h (est.)  ~3.3 h (est.)
+#
+# It is not simply that the third run has 20x more alignments: the cost *per
+# alignment* is ~90x worse, so total cost is closer to alignments x f(reference
+# size) than to alignments alone. Alignment count and reference size are
+# confounded in the only dataset where this has been measured, so the shortcut
+# below deliberately requires BOTH to be large -- it fires only inside the
+# region actually observed to fail. Every other run tries fasterq-dump first and
+# relies on the budget to catch a bad case, which costs one budget's wall time
+# but cannot mis-classify.
+#
+# The two extractors' output is byte-identical given --split-3 --skip-technical:
+# verified on SRR000001, and on all 307 GB of SRR28349113 (400,318,389 reads per
+# mate, cmp-clean). fastq-dump defaults differ from fasterq-dump's on both flags,
+# so neither may be dropped.
+_SRA_CONFIG = config["reads"]["sra"]
+SRA_FASTERQ_BUDGET_SECONDS = int(_SRA_CONFIG["fasterq_budget_minutes"]) * 60
+SRA_DIRECT_MIN_ALIGNMENTS = int(_SRA_CONFIG["direct_fastq_dump_min_alignments"])
+SRA_DIRECT_MIN_REFERENCE_BP = int(_SRA_CONFIG["direct_fastq_dump_min_reference_bp"])
+
+# The SRA REFERENCE table stores the reference in fixed-size rows, so the row
+# count reported by `vdb-dump --info` estimates the reference length.
+SRA_REFERENCE_CHUNK_BP = 5000
+
+
 def fastp_input(wildcards):
     """Get input fastqs for filtering."""
     sample_rows = get_sample_rows(wildcards.sample)
@@ -40,6 +76,10 @@ rule download_sra:
         r2=temp("results/fastqs/{sample}/{library}/{input_unit}/{accession}_2.fastq.gz"),
     params:
         outdir="results/fastqs/{sample}/{library}/{input_unit}",
+        fasterq_budget=SRA_FASTERQ_BUDGET_SECONDS,
+        direct_min_alignments=SRA_DIRECT_MIN_ALIGNMENTS,
+        direct_min_reference_bp=SRA_DIRECT_MIN_REFERENCE_BP,
+        reference_chunk_bp=SRA_REFERENCE_CHUNK_BP,
     threads: 4
     conda:
         "../envs/sra.yaml"
@@ -53,11 +93,64 @@ rule download_sra:
         mkdir -p {params.outdir}
         
         if prefetch --max-size 1T {wildcards.accession} 2>> {log}; then
-            fasterq-dump {wildcards.accession} \
-                -O {params.outdir} \
-                -e {threads} \
-                -t {resources.tmpdir} \
-                >> {log} 2>&1
+            # Table row counts describing the run's shape. For aligned (cSRA)
+            # submissions: SEQ = spots, PRIM = aligned reads, REF = reference
+            # chunks. Logged on every download so the thresholds below can be
+            # recalibrated from real data rather than re-derived by hand.
+            SRA_INFO=$(vdb-dump --info {wildcards.accession} 2>/dev/null)
+            echo "$SRA_INFO" | grep -E '^(SEQ|REF|PRIM|SEC) ' >> {log} || true
+
+            PRIM=$(echo "$SRA_INFO" \
+                | awk -F: '$1 ~ /^PRIM/ {{gsub(/[^0-9]/, "", $2); print $2; exit}}')
+            REF_ROWS=$(echo "$SRA_INFO" \
+                | awk -F: '$1 ~ /^REF/ {{gsub(/[^0-9]/, "", $2); print $2; exit}}')
+            PRIM=${{PRIM:-0}}
+            REF_BP=$(( ${{REF_ROWS:-0}} * {params.reference_chunk_bp} ))
+
+            # Skip fasterq-dump only where its lookup is known to be hopeless:
+            # many alignments AND a large reference. Either alone is not enough
+            # evidence to route around the faster default.
+            USE_FASTQ_DUMP=0
+            if [ "{params.direct_min_alignments}" -gt 0 ] \
+               && [ "$PRIM" -ge "{params.direct_min_alignments}" ] \
+               && [ "$REF_BP" -ge "{params.direct_min_reference_bp}" ]; then
+                USE_FASTQ_DUMP=1
+                echo "$PRIM primary alignments against ~${{REF_BP}} bp of reference:" \
+                     "skipping fasterq-dump, extracting with fastq-dump." >> {log}
+            fi
+
+            # Private temp dir so a timed-out attempt can be cleaned up whole.
+            FASTERQ_TMP=$(mktemp -d "{resources.tmpdir}/fasterq_{wildcards.accession}_XXXXXX")
+
+            if [ "$USE_FASTQ_DUMP" -eq 0 ]; then
+                if timeout {params.fasterq_budget} fasterq-dump {wildcards.accession} \
+                        -O {params.outdir} \
+                        -e {threads} \
+                        -t "$FASTERQ_TMP" \
+                        >> {log} 2>&1; then
+                    :
+                else
+                    # A killed fasterq-dump leaves a partial FASTQ behind. It
+                    # must be deleted, not compressed: pigz would happily gzip a
+                    # truncated file and hand silently corrupt reads to fastp.
+                    echo "fasterq-dump did not finish within {params.fasterq_budget}s;" \
+                         "discarding partial output and falling back to fastq-dump." >> {log}
+                    rm -f {params.outdir}/{wildcards.accession}*.fastq
+                    USE_FASTQ_DUMP=1
+                fi
+            fi
+
+            if [ "$USE_FASTQ_DUMP" -eq 1 ]; then
+                # --split-3 --skip-technical are required for parity with
+                # fasterq-dump's defaults; see the note at the top of this file.
+                fastq-dump {wildcards.accession} \
+                    --split-3 \
+                    --skip-technical \
+                    -O {params.outdir} \
+                    >> {log} 2>&1
+            fi
+
+            rm -rf "$FASTERQ_TMP"
             pigz -p {threads} {params.outdir}/{wildcards.accession}*.fastq
             rm -rf {wildcards.accession}
         else

--- a/workflow/rules/fastq.smk
+++ b/workflow/rules/fastq.smk
@@ -89,15 +89,31 @@ rule download_sra:
         "logs/download_sra/{sample}/{library}/{input_unit}/{accession}.txt"
     shell:
         """
-        rm -rf {wildcards.accession}
         mkdir -p {params.outdir}
-        
-        if prefetch --max-size 1T {wildcards.accession} 2>> {log}; then
+
+        # Everything this rule downloads or spills lives in one job-private
+        # directory, removed on exit however the job ends. prefetch previously
+        # wrote into the working directory, so every concurrent download_sra
+        # job created a sibling accession directory in the workflow root, and
+        # the rule's own `rm -rf <accession>` could delete another job's
+        # in-flight download whenever two sample rows shared an accession.
+        WORK=$(mktemp -d "{resources.tmpdir}/sra_{wildcards.accession}_XXXXXX")
+        trap 'rm -rf "$WORK"' EXIT
+
+        if prefetch --max-size 1T -O "$WORK" {wildcards.accession} 2>> {log}; then
+            # prefetch lays this out as <outdir>/<accession>/<accession>.sra,
+            # with any reference object the run needs alongside it. Passing the
+            # file path (rather than the bare accession) keeps resolution
+            # independent of the working directory; sibling references still
+            # resolve, and both extractors name their output from the basename.
+            SRA="$WORK/{wildcards.accession}/{wildcards.accession}.sra"
+            [ -f "$SRA" ] || SRA="$WORK/{wildcards.accession}/{wildcards.accession}.sralite"
+
             # Table row counts describing the run's shape. For aligned (cSRA)
             # submissions: SEQ = spots, PRIM = aligned reads, REF = reference
             # chunks. Logged on every download so the thresholds below can be
             # recalibrated from real data rather than re-derived by hand.
-            SRA_INFO=$(vdb-dump --info {wildcards.accession} 2>/dev/null)
+            SRA_INFO=$(vdb-dump --info "$SRA" 2>/dev/null)
             echo "$SRA_INFO" | grep -E '^(SEQ|REF|PRIM|SEC) ' >> {log} || true
 
             PRIM=$(echo "$SRA_INFO" \
@@ -119,14 +135,12 @@ rule download_sra:
                      "skipping fasterq-dump, extracting with fastq-dump." >> {log}
             fi
 
-            # Private temp dir so a timed-out attempt can be cleaned up whole.
-            FASTERQ_TMP=$(mktemp -d "{resources.tmpdir}/fasterq_{wildcards.accession}_XXXXXX")
-
             if [ "$USE_FASTQ_DUMP" -eq 0 ]; then
-                if timeout {params.fasterq_budget} fasterq-dump {wildcards.accession} \
+                mkdir -p "$WORK/fasterq"
+                if timeout {params.fasterq_budget} fasterq-dump "$SRA" \
                         -O {params.outdir} \
                         -e {threads} \
-                        -t "$FASTERQ_TMP" \
+                        -t "$WORK/fasterq" \
                         >> {log} 2>&1; then
                     :
                 else
@@ -143,16 +157,14 @@ rule download_sra:
             if [ "$USE_FASTQ_DUMP" -eq 1 ]; then
                 # --split-3 --skip-technical are required for parity with
                 # fasterq-dump's defaults; see the note at the top of this file.
-                fastq-dump {wildcards.accession} \
+                fastq-dump "$SRA" \
                     --split-3 \
                     --skip-technical \
                     -O {params.outdir} \
                     >> {log} 2>&1
             fi
 
-            rm -rf "$FASTERQ_TMP"
             pigz -p {threads} {params.outdir}/{wildcards.accession}*.fastq
-            rm -rf {wildcards.accession}
         else
             echo "Prefetch failed, trying ENA via ffq..." >> {log}
             ffq --ftp {wildcards.accession} 2>> {log} \

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -24,6 +24,42 @@ properties:
       mark_duplicates:
         type: boolean
         default: true
+      sra:
+        type: object
+        additionalProperties: false
+        default: {}
+        description: >
+          Controls how SRA accessions are converted to FASTQ. fasterq-dump is
+          the default extractor; fastq-dump is a byte-identical fallback used
+          only when fasterq-dump's alignment lookup does not scale. See the
+          commentary in workflow/rules/fastq.smk.
+        properties:
+          fasterq_budget_minutes:
+            type: integer
+            minimum: 1
+            default: 360
+            description: >
+              Wall-clock budget for fasterq-dump. If it has not finished within
+              this many minutes, its partial output is discarded and fastq-dump
+              extracts the accession instead. Set generously: this is a
+              backstop, not a target.
+          direct_fastq_dump_min_alignments:
+            type: integer
+            minimum: 0
+            default: 300000000
+            description: >
+              Skip fasterq-dump entirely (go straight to fastq-dump) when the
+              run has at least this many primary alignments AND a reference at
+              least direct_fastq_dump_min_reference_bp long. Both conditions
+              must hold. Set to 0 to disable the shortcut and always let the
+              budget decide.
+          direct_fastq_dump_min_reference_bp:
+            type: integer
+            minimum: 0
+            default: 3000000000
+            description: >
+              Reference-length half of the shortcut condition above, in base
+              pairs. Estimated from the SRA REFERENCE table row count.
 
   reference:
     type: object


### PR DESCRIPTION
## Problem

`download_sra` cannot extract some reference-aligned (cSRA) accessions at all. On a *Pseudophryne corroboree* run (`GCA_028390025.1`, 8.87 Gbp), 11 of 20 accessions burned two 48 h walls and ~2,100 CPU-hours without producing a single FASTQ.

The cause is `fasterq-dump`'s lookup phase. For reference-aligned submissions it re-pairs reads by building a spot-id lookup over the entire `PRIMARY_ALIGNMENT` table and sorting it externally. Forensics on the leftover temp dirs show it emitting one 244 MB sorted run every ~2 hours, steadily, for 18.6 h — ~122 MB/h, still in lookup construction, nowhere near done.

## Measurements

| accession | aligned reads (PRIM) | reference | `fasterq-dump` | `fastq-dump` |
|---|---|---|---|---|
| `SRR000001` | 0 (unaligned) | – | 3 s | 6 s |
| `SRR28349113` | 54.2M | 0.69 Gbp | **46.8 min** | 87.9 min |
| `SRR28349114` | 1,108.7M | 8.88 Gbp | ~577 h (est.) | **~3.3 h** (est.) |

The blow-up is not just "more alignments". The third run has 20× more, but is ~90× slower *per alignment*, so cost tracks `alignments × f(reference size)` rather than alignment count alone.

`fastq-dump` streams in spot order and builds no lookup, so it is unaffected — but it is ~2× slower everywhere else, so it must not become the default.

## What was ruled out

- **Buffer tuning** (`--curcache 4G --bufsize 64M --mem 8G`): 1.46× at best, against the ~29× needed. Measured head-to-head at 45 min per arm.
- **Node-local temp**: `fasterq-dump` sizes the lookup upfront (~176 GB) and refuses to start with `disk-limit exeeded`.
- **`sam-dump`**: viable (~13.8 h) but 4× slower than `fastq-dump` and needs `collate` to re-pair.
- **ENA mirrors**: this BioProject has no `fastq_ftp`, `submitted_ftp` or `sra_ftp` at ENA, so the rule's existing ffq fallback could not have helped.

## Changes

**1. `fastq-dump` as a fallback, never the default.**

- Log `SEQ/PRIM/REF/SEC` on every download, so thresholds can be recalibrated from real data later.
- Skip `fasterq-dump` outright only when a run has **both** many alignments **and** a large reference. Both are required because the two axes are confounded in the only dataset measured — the shortcut fires only inside the region actually observed to fail.
- Otherwise run `fasterq-dump` under a wall-clock budget (default 6 h) and fall back if it expires. The budget cannot mis-classify, which the thresholds can.
- A timed-out `fasterq-dump` leaves a partial FASTQ; it is deleted before the fallback runs, since `pigz` would otherwise compress a truncated file and hand silently corrupt reads to `fastp`.

**2. Downloads into a job-private directory.**

`prefetch` ran without `-O`, writing one `<accession>/` dir into the workflow root with jobs running up to 500-wide, and the rule bracketed itself with `rm -rf <accession>`. If two sample rows reference one accession, either job's teardown can delete the other's in-flight download. Each job now gets its own directory under `resources.tmpdir`, removed by an `EXIT` trap so it cleans up on timeout or cancellation too.

## Verification

- **Output equivalence checked, not assumed.** Given `--split-3 --skip-technical` (both needed — `fastq-dump`'s defaults differ from `fasterq-dump`'s on each), the two produce byte-identical FASTQ. Confirmed on `SRR000001` and on all 307 GB of `SRR28349113`: 400,318,389 reads per mate, `cmp`-clean.
- **Routing** exercised against real `vdb-dump` output for all three shapes, including a flat run where `PRIM`/`REF` lines are absent and the parse degrades safely to 0.
- **Both branches run end-to-end** on `SRR000001`: normal budget (`fasterq-dump` succeeds) and a 1-second budget (forced timeout → partial cleanup → fallback). Same reads either way; no accession dir left behind; scratch removed.
- **Full DAG builds** (75 jobs) with the workflow profile.
- Passing a full `.sra` path still resolves a run's sibling reference object, and both tools name output from the basename, so downstream globs are unchanged.

## Notes for reviewers

- **No CI test pins the byte-identity claim**, which is the entire safety argument for the fallback. A test config with a low `fasterq_budget_minutes` would force the path and assert parity — worth adding, and I'm happy to.
- The thresholds (3e8 alignments, 3 Gbp) are calibrated on three accessions from one project. The commit message and an `fastq.smk` header comment say so explicitly, and the logging exists so they can be revisited.
- `test_markdup` fails on this machine (`sambamba` on macOS/arm64), identically on an unmodified tree — pre-existing, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)